### PR TITLE
Improve error handling, retry logic, and accessibility

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simhammer-frontend",
-  "version": "1.2.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simhammer-frontend",
-      "version": "1.2.0",
+      "version": "1.5.0",
       "dependencies": {
         "next": "14.2.4",
         "react": "^18.3.1",

--- a/frontend/src/app/components/ErrorBoundary.tsx
+++ b/frontend/src/app/components/ErrorBoundary.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Component, type ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  handleReset = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) return this.props.fallback;
+
+      return (
+        <div className="card border-red-500/20 p-6 text-center space-y-3">
+          <p className="text-sm font-medium text-red-400">
+            Something went wrong
+          </p>
+          <p className="text-xs text-red-400/60 font-mono whitespace-pre-wrap break-words max-h-24 overflow-auto">
+            {this.state.error?.message || "An unexpected error occurred"}
+          </p>
+          <button
+            onClick={this.handleReset}
+            className="px-4 py-2 text-xs font-medium text-white bg-surface-2 border border-border rounded-lg hover:border-gray-500 transition-colors"
+          >
+            Try again
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/app/components/TopGearItemSelector.tsx
+++ b/frontend/src/app/components/TopGearItemSelector.tsx
@@ -386,6 +386,7 @@ export default function TopGearItemSelector({
                       height={24}
                       className="w-full h-full"
                       loading="lazy"
+                      onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
                     />
                   </div>
                   <ItemDetails
@@ -469,6 +470,7 @@ export default function TopGearItemSelector({
                       height={24}
                       className="w-full h-full"
                       loading="lazy"
+                      onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
                     />
                   </div>
                   <ItemDetails

--- a/frontend/src/app/drop-finder/page.tsx
+++ b/frontend/src/app/drop-finder/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useSimContext } from "../components/SimContext";
 import { detectClass } from "../lib/parseAddonString";
-import { API_URL } from "../lib/api";
+import { API_URL, apiFetch, throwResponseError } from "../lib/api";
 
 interface Instance {
   id: number;
@@ -101,6 +101,7 @@ export default function DropFinderPage() {
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
+  const [instanceError, setInstanceError] = useState("");
   const [difficulty, setDifficulty] = useState<Difficulty>("heroic");
   const [dungeonDiff, setDungeonDiff] = useState("mythic+10");
 
@@ -108,12 +109,23 @@ export default function DropFinderPage() {
   const specName = useMemo(() => detectSpec(simcInput), [simcInput]);
   const hasCharacter = simcInput.trim().length >= 10;
 
-  useEffect(() => {
-    fetch(`${API_URL}/api/instances`)
-      .then((r) => r.json())
+  function fetchInstances() {
+    setInstanceError("");
+    apiFetch(`${API_URL}/api/instances`)
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
       .then(setInstances)
-      .catch(() => {});
-  }, []);
+      .catch((err) => {
+        setInstanceError(
+          err instanceof Error ? err.message : "Failed to load instances"
+        );
+      });
+  }
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { fetchInstances(); }, []);
 
   useEffect(() => {
     if (!selectedId) {
@@ -131,8 +143,11 @@ export default function DropFinderPage() {
     const url = selectedId.startsWith("type:")
       ? `${API_URL}/api/instances/type/${selectedId.slice(5)}/drops`
       : `${API_URL}/api/instances/${selectedId}/drops`;
-    fetch(`${url}${qs ? `?${qs}` : ""}`)
-      .then((r) => r.json())
+    apiFetch(`${url}${qs ? `?${qs}` : ""}`)
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
       .then((data) => {
         setDrops(data.detail ? null : data);
       })
@@ -177,7 +192,7 @@ export default function DropFinderPage() {
         }
       }
 
-      const res = await fetch(`${API_URL}/api/droptimizer/sim`, {
+      const res = await apiFetch(`${API_URL}/api/droptimizer/sim`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -189,11 +204,9 @@ export default function DropFinderPage() {
           threads,
           ...(selectedTalent ? { talents: selectedTalent } : {}),
         }),
+        timeoutMs: 60_000,
       });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.detail || `Server error ${res.status}`);
-      }
+      if (!res.ok) await throwResponseError(res);
       const data = await res.json();
       window.location.href = `/sim/${data.id}`;
     } catch (err: unknown) {
@@ -449,6 +462,8 @@ export default function DropFinderPage() {
                         src={`https://wow.zamimg.com/images/wow/icons/small/${item.icon}.jpg`}
                         alt=""
                         className="w-6 h-6 rounded"
+                        loading="lazy"
+                        onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
                       />
                       <a
                         href={`https://www.wowhead.com/item=${item.item_id}`}
@@ -502,8 +517,21 @@ export default function DropFinderPage() {
         </div>
       )}
 
+      {/* Instance load error */}
+      {instanceError && (
+        <div className="card border-red-500/20 p-6 text-center space-y-3">
+          <p className="text-sm text-red-400">{instanceError}</p>
+          <button
+            onClick={fetchInstances}
+            className="px-4 py-2 text-xs font-medium text-white bg-surface-2 border border-border rounded-lg hover:border-gray-500 transition-colors"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
       {/* Empty state */}
-      {!selectedId && !loading && !category && (
+      {!selectedId && !loading && !category && !instanceError && (
         <p className="text-sm text-muted text-center py-6">
           Select a category to get started.
         </p>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -100,3 +100,13 @@ input[type="range"]:active::-moz-range-thumb {
 input[type="range"]:focus-visible {
   @apply outline-none;
 }
+
+/* Respect reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Script from "next/script";
 import DesktopAppLink from "./components/DesktopAppLink";
+import ErrorBoundary from "./components/ErrorBoundary";
 import SettingsPopover from "./components/SettingsPopover";
 import { SimProvider } from "./components/SimContext";
 import SimSharedConfig from "./components/SimSharedConfig";
@@ -61,7 +62,7 @@ export default function RootLayout({
           <main className="max-w-5xl mx-auto px-6 py-10">
             <SimTypeCards />
             <SimSharedConfig />
-            {children}
+            <ErrorBoundary>{children}</ErrorBoundary>
           </main>
         </SimProvider>
         <footer className="border-t border-border/50 mt-16 py-6">

--- a/frontend/src/app/lib/api.ts
+++ b/frontend/src/app/lib/api.ts
@@ -5,3 +5,68 @@ export const API_URL =
   typeof window !== "undefined" && window.electronAPI
     ? "http://127.0.0.1:17384"
     : process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+/** Default timeout for API requests (30 seconds). */
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Fetch wrapper with timeout support and user-friendly error messages.
+ * Returns the Response on success; throws a descriptive Error on failure.
+ */
+export async function apiFetch(
+  url: string,
+  init?: RequestInit & { timeoutMs?: number },
+): Promise<Response> {
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, ...fetchInit } = init ?? {};
+
+  const controller = new AbortController();
+  // Merge external signal so callers can still abort independently
+  if (fetchInit.signal) {
+    fetchInit.signal.addEventListener("abort", () => controller.abort());
+  }
+  fetchInit.signal = controller.signal;
+
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(url, fetchInit);
+    return res;
+  } catch (err: unknown) {
+    if (controller.signal.aborted && !(init?.signal?.aborted)) {
+      throw new Error(
+        "The request timed out. The server may be busy — please try again.",
+      );
+    }
+    if (err instanceof DOMException && err.name === "AbortError") {
+      throw err; // Caller-initiated abort, re-throw as-is
+    }
+    throw new Error(
+      "Could not reach the server. Check your connection and try again.",
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Parse an error response body and throw with the detail message.
+ * Use after checking `!res.ok`.
+ */
+export async function throwResponseError(res: Response): Promise<never> {
+  const data = await res.json().catch(() => ({}));
+  const detail = (data as Record<string, unknown>).detail;
+
+  if (res.status === 429) {
+    throw new Error("Too many requests. Please wait a moment and try again.");
+  }
+  if (res.status >= 500) {
+    throw new Error(
+      typeof detail === "string"
+        ? detail
+        : "The server encountered an error. Please try again.",
+    );
+  }
+  throw new Error(
+    typeof detail === "string" ? detail : `Request failed (${res.status})`,
+  );
+}

--- a/frontend/src/app/quick-sim/page.tsx
+++ b/frontend/src/app/quick-sim/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useSimContext } from "../components/SimContext";
-import { API_URL } from "../lib/api";
+import { API_URL, apiFetch, throwResponseError } from "../lib/api";
 
 export default function QuickSimPage() {
   const { simcInput, fightStyle, threads, selectedTalent } = useSimContext();
@@ -19,7 +19,7 @@ export default function QuickSimPage() {
     }
     setSubmitting(true);
     try {
-      const res = await fetch(`${API_URL}/api/sim`, {
+      const res = await apiFetch(`${API_URL}/api/sim`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -31,11 +31,9 @@ export default function QuickSimPage() {
           threads,
           ...(selectedTalent ? { talents: selectedTalent } : {}),
         }),
+        timeoutMs: 60_000,
       });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.detail || `Server error ${res.status}`);
-      }
+      if (!res.ok) await throwResponseError(res);
       const data = await res.json();
       window.location.href = `/sim/${data.id}`;
     } catch (err: unknown) {

--- a/frontend/src/app/sim/[id]/SimResultClient.tsx
+++ b/frontend/src/app/sim/[id]/SimResultClient.tsx
@@ -7,7 +7,7 @@ import SimStatus from "../../components/SimStatus";
 import StatWeightsTable from "../../components/StatWeightsTable";
 import TopGearResults from "../../components/TopGearResults";
 
-import { API_URL } from "../../lib/api";
+import { API_URL, apiFetch } from "../../lib/api";
 
 interface JobData {
   id: string;
@@ -34,44 +34,76 @@ export default function SimResultClient() {
 
   const [job, setJob] = useState<JobData | null>(null);
   const [fetchError, setFetchError] = useState("");
+  const [retrying, setRetrying] = useState(false);
 
   useEffect(() => {
     if (!id || id === "_") return;
     setFetchError("");
-    let active = true;
+    const controller = new AbortController();
+    let failCount = 0;
+    const MAX_RETRIES = 5;
+
     async function poll() {
+      if (controller.signal.aborted) return;
       try {
-        const res = await fetch(`${API_URL}/api/sim/${id}`);
+        const res = await apiFetch(`${API_URL}/api/sim/${id}`, {
+          signal: controller.signal,
+          timeoutMs: 15_000,
+        });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data: JobData = await res.json();
-        if (active) setJob(data);
+        if (controller.signal.aborted) return;
+        failCount = 0;
+        setRetrying(false);
+        setJob(data);
         if (data.status === "pending" || data.status === "running") {
           setTimeout(poll, 2000);
         }
       } catch (err) {
-        if (active)
+        if (controller.signal.aborted) return;
+        if (err instanceof DOMException && err.name === "AbortError") return;
+
+        failCount++;
+        if (failCount <= MAX_RETRIES) {
+          setRetrying(true);
+          const backoff = Math.min(2000 * Math.pow(2, failCount - 1), 16000);
+          setTimeout(poll, backoff);
+        } else {
+          setRetrying(false);
           setFetchError(
             err instanceof Error ? err.message : "Failed to fetch status"
           );
+        }
       }
     }
     poll();
-    return () => { active = false; };
+    return () => controller.abort();
   }, [id]);
 
   if (fetchError) {
     return (
-      <div className="card border-red-500/20 p-6">
-        <p className="text-sm font-medium text-red-400 mb-1">Error</p>
+      <div className="card border-red-500/20 p-6 text-center space-y-3">
+        <p className="text-sm font-medium text-red-400">Error</p>
         <p className="text-sm text-red-400/70">{fetchError}</p>
+        <button
+          onClick={() => window.location.reload()}
+          className="px-4 py-2 text-xs font-medium text-white bg-surface-2 border border-border rounded-lg hover:border-gray-500 transition-colors"
+        >
+          Retry
+        </button>
       </div>
     );
   }
 
   if (!job) {
     return (
-      <div className="flex flex-col items-center justify-center py-20">
+      <div className="flex flex-col items-center justify-center py-20 gap-3">
         <div className="w-8 h-8 border-2 border-border border-t-gold rounded-full animate-spin" />
+        {retrying && (
+          <p className="text-xs text-yellow-500/80">
+            Connection lost — retrying…
+          </p>
+        )}
       </div>
     );
   }

--- a/frontend/src/app/top-gear/page.tsx
+++ b/frontend/src/app/top-gear/page.tsx
@@ -10,7 +10,7 @@ import {
   detectClass,
   classMaxArmor,
 } from "../lib/parseAddonString";
-import { API_URL } from "../lib/api";
+import { API_URL, apiFetch, throwResponseError } from "../lib/api";
 
 export default function TopGearPage() {
   const { simcInput, fightStyle, threads, selectedTalent } = useSimContext();
@@ -60,7 +60,7 @@ export default function TopGearPage() {
     setError("");
     setSubmitting(true);
     try {
-      const res = await fetch(`${API_URL}/api/top-gear/sim`, {
+      const res = await apiFetch(`${API_URL}/api/top-gear/sim`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -75,11 +75,9 @@ export default function TopGearPage() {
           threads,
           ...(selectedTalent ? { talents: selectedTalent } : {}),
         }),
+        timeoutMs: 60_000,
       });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.detail || `Server error ${res.status}`);
-      }
+      if (!res.ok) await throwResponseError(res);
       const data = await res.json();
       window.location.href = `/sim/${data.id}`;
     } catch (err: unknown) {


### PR DESCRIPTION
## Summary
- **`apiFetch` wrapper** (`lib/api.ts`): Configurable timeout (default 30s), user-friendly error messages for network failures and timeouts, replaces raw `fetch` across all sim pages
- **`ErrorBoundary` component**: Catches unexpected React crashes with a styled recovery UI, wrapped around all page content in the root layout
- **Retry logic**: Sim result polling (`SimResultClient`) now retries up to 5 times on transient failures with exponential backoff; Drop Finder instance loading has a retry button on failure
- **Image error handling**: Broken item icons in Top Gear and Drop Finder are hidden instead of showing broken-image placeholders
- **Accessibility**: `prefers-reduced-motion` media query disables animations/transitions globally
- **Version bump**: 1.2.0 → 1.5.0

## Test plan
- [ ] Verify quick-sim, top-gear, and drop-finder pages submit sims successfully
- [ ] Kill the backend and confirm timeout/network error messages appear (not raw fetch errors)
- [ ] Confirm sim result page retries polling on transient API failures
- [ ] Confirm Drop Finder shows retry button when instance list fails to load
- [ ] Check broken item icon URLs don't show broken-image placeholder
- [ ] Enable "prefers reduced motion" in OS/browser and verify no animations play
- [ ] Trigger a React error (e.g., throw in a component) and verify ErrorBoundary renders