### PR TITLE
Add macOS code signing and notarization

### DIFF
--- a/.github/workflows/desktop-build-platform.yml
+++ b/.github/workflows/desktop-build-platform.yml
@@ -9,6 +9,17 @@ on:
       os:
         required: true
         type: string
+    secrets:
+      CSC_LINK:
+        required: false
+      CSC_KEY_PASSWORD:
+        required: false
+      APPLE_ID:
+        required: false
+      APPLE_APP_SPECIFIC_PASSWORD:
+        required: false
+      APPLE_TEAM_ID:
+        required: false
 
 env:
   SIMC_VERSION: HEAD
@@ -125,6 +136,11 @@ jobs:
         run: cd desktop && npx electron-builder --publish never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_LINK: ${{ inputs.platform == 'macos' && secrets.CSC_LINK || '' }}
+          CSC_KEY_PASSWORD: ${{ inputs.platform == 'macos' && secrets.CSC_KEY_PASSWORD || '' }}
+          APPLE_ID: ${{ inputs.platform == 'macos' && secrets.APPLE_ID || '' }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ inputs.platform == 'macos' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
+          APPLE_TEAM_ID: ${{ inputs.platform == 'macos' && secrets.APPLE_TEAM_ID || '' }}
 
       # -- Upload --
       - name: Upload artifacts

--- a/.github/workflows/desktop-macos.yml
+++ b/.github/workflows/desktop-macos.yml
@@ -9,3 +9,9 @@ jobs:
     with:
       platform: macos
       os: macos-latest
+    secrets:
+      CSC_LINK: ${{ secrets.CSC_LINK }}
+      CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -24,6 +24,12 @@ jobs:
     with:
       platform: macos
       os: macos-latest
+    secrets:
+      CSC_LINK: ${{ secrets.CSC_LINK }}
+      CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
   release:
     needs: [windows, linux, macos]

--- a/desktop/build/entitlements.mac.plist
+++ b/desktop/build/entitlements.mac.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -55,7 +55,12 @@
     },
     "mac": {
       "target": "dmg",
-      "icon": "build/icon.png"
+      "icon": "build/icon.png",
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.plist",
+      "notarize": true
     },
     "linux": {
       "target": ["AppImage", "deb"]


### PR DESCRIPTION
## Summary
- Configures electron-builder for macOS code signing (hardened runtime + entitlements) and notarization
- Passes signing secrets through the reusable workflow to the macOS build step
- Non-macOS builds are completely unaffected — secrets are optional and ignored on other platforms

Closes #21

## Required secrets

The following repository secrets need to be added before this will sign builds:

| Secret | Description |
|---|---|
| `CSC_LINK` | Base64-encoded Developer ID Application `.p12` certificate |
| `CSC_KEY_PASSWORD` | Password for the `.p12` file |
| `APPLE_ID` | Apple ID email for notarization |
| `APPLE_APP_SPECIFIC_PASSWORD` | App-specific password from appleid.apple.com |
| `APPLE_TEAM_ID` | 10-character Apple Developer Team ID |

## Setting the secrets

I have the certificate and credentials ready to go. Easiest path would be to add me as a collaborator so I can set the secrets directly via `gh secret set`. Otherwise, I can share the values securely through LastPass if you share your email.

Without the secrets configured, macOS builds will continue to work as before (unsigned).

## Test plan
- [ ] Add repository secrets
- [ ] Trigger a macOS build via `workflow_dispatch`
- [ ] Verify the DMG is signed: `codesign --verify --deep --strict SimHammer.app`
- [ ] Verify notarization: `spctl --assess --type execute SimHammer.app`
- [ ] Confirm the app opens without Gatekeeper warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)