### PR TITLE
feat: allow configurable simc timeout via SIMC_TIMEOUT env var

### DIFF
--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -53,6 +53,7 @@ ENV FRONTEND_DIR=/app/frontend
 ENV DATABASE_URL=/app/db/simhammer.db
 ENV BIND_HOST=0.0.0.0
 ENV PORT=8000
+ENV SIMC_TIMEOUT=600
 
 EXPOSE 8000
 ENTRYPOINT ["/app/standalone-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Jobs are automatically garbage collected on insert. Defaults:
 | `FRONTEND_DIR` | _(unset)_ | Path to static frontend files (standalone mode only) |
 | `MAX_JOBS` | `50` / `200` | Max jobs to retain (desktop / web). Oldest are deleted on insert |
 | `MAX_COMBINATIONS` | `500` | Max gear combinations for Top Gear sims |
+| `SIMC_TIMEOUT` | `600` | Timeout in seconds for simc progress (per line) |
 
 ## CI/CD
 

--- a/backend/core/src/simc_runner.rs
+++ b/backend/core/src/simc_runner.rs
@@ -84,7 +84,12 @@ fn set_process_affinity(pid: u32, threads: u32) {
     }
 }
 
-const SIMC_TIMEOUT_SECS: u64 = 600;
+fn get_simc_timeout() -> u64 {
+    std::env::var("SIMC_TIMEOUT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(600)
+}
 
 fn max_threads() -> u32 {
     std::thread::available_parallelism()
@@ -281,10 +286,11 @@ async fn run_simc_subprocess(
     if let Some(err_stream) = stderr {
         let mut reader = BufReader::new(err_stream);
         let mut line_buf = String::new();
+        let timeout_secs = get_simc_timeout();
         loop {
             line_buf.clear();
             match tokio::time::timeout(
-                std::time::Duration::from_secs(SIMC_TIMEOUT_SECS),
+                std::time::Duration::from_secs(timeout_secs),
                 reader.read_line(&mut line_buf),
             )
             .await
@@ -295,7 +301,7 @@ async fn run_simc_subprocess(
                     // Timeout — kill the child
                     unregister_process(job_id);
                     let _ = child.kill().await;
-                    return Err(format!("simc timed out after {}s", SIMC_TIMEOUT_SECS));
+                    return Err(format!("simc timed out after {}s", timeout_secs));
                 }
                 Ok(Ok(_)) => {
                     let line = line_buf.trim_end().to_string();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - DATA_DIR=/app/resources/data
       - DATABASE_URL=/app/db/simhammer.db
       - PORT=8000
+      - SIMC_TIMEOUT=${SIMC_TIMEOUT:-600}
 
   frontend:
     build:


### PR DESCRIPTION
 Description:
  This PR introduces a configurable timeout for simc subprocesses, addressing issues where long simulations (especially
  complex Droptimizers or Top Gear runs on slower hardware) would fail with a hardcoded 600s timeout.

  Changes:
   - backend/core/src/simc_runner.rs: Replaced the SIMC_TIMEOUT_SECS constant with a get_simc_timeout() function that
     reads the SIMC_TIMEOUT environment variable.
   - docker-compose.yml: Added SIMC_TIMEOUT to the backend environment, defaulting to 600s using the
     ${SIMC_TIMEOUT:-600} syntax.
   - Dockerfile.standalone: Added ENV SIMC_TIMEOUT=600 to the standalone image build.
   - README.md: Documented the new environment variable in the "Environment Variables" section.

  Why this is needed:
  The current 600s (10 minutes) timeout is applied per line of output from simc. On slower machines or with extremely
  large simulations, simc might take longer than 10 minutes to process a single iteration/profileset, causing the
  simulation to fail even if it's still working. Making this value configurable allows users to adapt the timeout to
  their hardware or specific simulation needs without modifying the source code.

  How to test:
   1. Run the app with a low timeout: SIMC_TIMEOUT=10 docker compose up.
   2. Launch a simulation that takes more than 10s. It should fail with the new timeout value in the error message.
   3. Run with a higher timeout (e.g., 1200) to confirm that longer simulations now pass.