### PR TITLE
Select simmed row to visualize in character sheet and addded slot name near the item itself (#59)

### DIFF
--- a/frontend/src/app/components/GearOverview.tsx
+++ b/frontend/src/app/components/GearOverview.tsx
@@ -47,6 +47,8 @@ interface GearOverviewProps {
   characterRenderUrl?: string | null;
   /** Slots to highlight as upgrades */
   upgradeSlots?: Set<string>;
+  /** Slots to highlight as downgrades */
+  downgradeSlots?: Set<string>;
 }
 
 export default function GearOverview({
@@ -54,6 +56,7 @@ export default function GearOverview({
   title = 'Equipped Gear',
   characterRenderUrl,
   upgradeSlots,
+  downgradeSlots,
 }: GearOverviewProps) {
   const allItemQueries = useMemo(() => {
     const seen = new Set<string>();
@@ -120,6 +123,7 @@ export default function GearOverview({
                       slot={slot}
                       item={gear[slot]}
                       isUpgrade={upgradeSlots?.has(slot)}
+                      isDowngrade={downgradeSlots?.has(slot)}
                       itemInfoMap={itemInfoMap}
                       enchantInfoMap={enchantInfoMap}
                       gemInfoMap={gemInfoMap}
@@ -134,6 +138,7 @@ export default function GearOverview({
                       slot={slot}
                       item={gear[slot]}
                       isUpgrade={upgradeSlots?.has(slot)}
+                      isDowngrade={downgradeSlots?.has(slot)}
                       itemInfoMap={itemInfoMap}
                       enchantInfoMap={enchantInfoMap}
                       gemInfoMap={gemInfoMap}
@@ -149,6 +154,7 @@ export default function GearOverview({
                     slot={slot}
                     item={gear[slot]}
                     isUpgrade={upgradeSlots?.has(slot)}
+                    isDowngrade={downgradeSlots?.has(slot)}
                     itemInfoMap={itemInfoMap}
                     enchantInfoMap={enchantInfoMap}
                     gemInfoMap={gemInfoMap}
@@ -169,6 +175,7 @@ export function GearSlotRow({
   slot,
   item,
   isUpgrade,
+  isDowngrade,
   itemInfoMap,
   enchantInfoMap,
   gemInfoMap,
@@ -177,6 +184,7 @@ export function GearSlotRow({
   slot: string;
   item?: GearItem;
   isUpgrade?: boolean;
+  isDowngrade?: boolean;
   itemInfoMap: Record<number, ItemInfo>;
   enchantInfoMap: Record<number, EnchantInfo>;
   gemInfoMap: Record<number, GemInfo>;
@@ -224,6 +232,15 @@ export function GearSlotRow({
           }}
         />
       )}
+      {isDowngrade && (
+        <div
+          className="pointer-events-none absolute inset-0 rounded-lg bg-red-500/[0.15] ring-1 ring-red-500/30"
+          style={{
+            maskImage: `linear-gradient(${fadeDir}, black 20%, transparent 85%)`,
+            WebkitMaskImage: `linear-gradient(${fadeDir}, black 20%, transparent 85%)`,
+          }}
+        />
+      )}
       <div className="h-7 w-7 shrink-0 overflow-hidden rounded border border-border">
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
@@ -254,7 +271,11 @@ export function GearSlotRow({
             </span>
           ) : isUpgrade ? (
             <span className="shrink-0 rounded bg-emerald-500/10 px-1 py-px text-[8px] font-bold uppercase tracking-wider text-emerald-400">
-              New
+              Upgrade
+            </span>
+          ) : isDowngrade ? (
+            <span className="shrink-0 rounded bg-red-500/10 px-1 py-px text-[8px] font-bold uppercase tracking-wider text-red-400">
+              Downgrade
             </span>
           ) : null}
           {item.origin === 'vault' && (

--- a/frontend/src/app/components/TopGearResults.tsx
+++ b/frontend/src/app/components/TopGearResults.tsx
@@ -56,7 +56,7 @@ interface TopGearResultsProps {
   elapsedTime?: number;
 }
 
-// WoW character sheet order: left column, right column, then weapons
+// WoW, character sheet order: left column, right column, then weapons
 const GEAR_ORDER_LEFT = ['head', 'neck', 'shoulder', 'back', 'chest', 'wrist'];
 const GEAR_ORDER_RIGHT = [
   'hands',
@@ -93,6 +93,14 @@ export default function TopGearResults({
   const hasEncounterData = results.some((r) => r.items.some((it) => it.encounter));
   type GroupMode = 'rank' | 'encounter';
   const [groupMode, setGroupMode] = useState<GroupMode>('rank');
+  const [selectedResultName, setSelectedResultName] = useState<string | null>(null);
+
+  const selectedResult = useMemo(() => {
+    if (selectedResultName) {
+      return results.find((r) => r.name === selectedResultName) || bestResult;
+    }
+    return bestResult;
+  }, [selectedResultName, results, bestResult]);
 
   const groupedResults = useMemo(() => {
     if (groupMode === 'rank' || !hasEncounterData) return null;
@@ -110,17 +118,18 @@ export default function TopGearResults({
     });
   }, [results, groupMode, hasEncounterData]);
 
-  // Build the full gear set for best result: start with equipped, overlay upgrades
   const bestGearSet = useMemo(() => {
     if (!equippedGear) return {} as Record<string, GearItem>;
     const gearSet: Record<string, GearItem> = {};
+
     for (const slot of ALL_SLOTS) {
       if (equippedGear[slot]) {
         gearSet[slot] = { ...equippedGear[slot] };
       }
     }
-    if (bestResult && bestResult.delta > 0) {
-      for (const it of bestResult.items) {
+
+    if (selectedResult) {
+      for (const it of selectedResult.items) {
         if (!it.is_kept && it.slot === 'off_hand' && it.item_id === 0) {
           delete gearSet.off_hand;
           continue;
@@ -131,17 +140,27 @@ export default function TopGearResults({
       }
     }
     return gearSet;
-  }, [equippedGear, bestResult]);
+  }, [equippedGear, selectedResult]);
 
   const upgradeSlots = useMemo(() => {
     const slots = new Set<string>();
-    if (bestResult && bestResult.delta > 0) {
-      for (const it of bestResult.items) {
+    if (selectedResult && selectedResult.delta > 0) {
+      for (const it of selectedResult.items) {
         if (!it.is_kept && it.item_id > 0) slots.add(it.slot);
       }
     }
     return slots;
-  }, [bestResult]);
+  }, [selectedResult]);
+
+  const downgradeSlots = useMemo(() => {
+    const slots = new Set<string>();
+    if (selectedResult && selectedResult.delta < 0) {
+      for (const it of selectedResult.items) {
+        if (!it.is_kept && it.item_id > 0) slots.add(it.slot);
+      }
+    }
+    return slots;
+  }, [selectedResult]);
 
   // Collect all item queries from results (for rankings ItemTag)
   const allItemQueries = useMemo(() => {
@@ -212,7 +231,7 @@ export default function TopGearResults({
         playerName={playerName}
         playerClass={playerClass}
         playerRealm={playerRealm}
-        dps={bestResult && bestResult.delta > 0 ? bestResult.dps : baseDps}
+        dps={selectedResult && selectedResult.delta > 0 ? selectedResult.dps : baseDps}
         dpsError={dpsError}
         dpsErrorPct={dpsErrorPct}
         fightLength={fightLength}
@@ -221,10 +240,10 @@ export default function TopGearResults({
         targetError={targetError}
         elapsedTime={elapsedTime}
       >
-        {bestResult && bestResult.delta > 0 ? (
+        {selectedResult && selectedResult.delta > 0 ? (
           <div className="mt-4 inline-flex items-center gap-1.5 rounded-md bg-emerald-500/10 px-3 py-1.5 text-emerald-400">
             <span className="text-sm font-semibold tabular-nums">
-              +{Math.round(bestResult.delta).toLocaleString()}
+              +{Math.round(selectedResult.delta).toLocaleString()}
             </span>
             <span className="text-xs opacity-60">upgrade</span>
           </div>
@@ -235,12 +254,15 @@ export default function TopGearResults({
 
       {/* Gear Overview */}
       {hasGearOverview && (
-        <GearOverview
-          gear={bestGearSet}
-          title="Best Gear"
-          characterRenderUrl={characterRenderUrl}
-          upgradeSlots={upgradeSlots}
-        />
+        <>
+          <GearOverview
+            gear={bestGearSet}
+            title={selectedResultName && selectedResultName !== bestResult?.name ? 'Selected Gear' : 'Best Gear'}
+            characterRenderUrl={characterRenderUrl}
+            upgradeSlots={upgradeSlots}
+            downgradeSlots={downgradeSlots}
+          />
+        </>
       )}
 
       {/* Rankings */}
@@ -259,11 +281,10 @@ export default function TopGearResults({
                   <button
                     key={mode}
                     onClick={() => setGroupMode(mode)}
-                    className={`rounded border px-2.5 py-1 text-[11px] font-medium transition-all ${
-                      groupMode === mode
-                        ? 'border-white bg-white text-black'
-                        : 'border-border bg-surface-2 text-gray-400 hover:border-gray-500 hover:text-white'
-                    }`}
+                    className={`rounded border px-2.5 py-1 text-[11px] font-medium transition-all ${groupMode === mode
+                      ? 'border-white bg-white text-black'
+                      : 'border-border bg-surface-2 text-gray-400 hover:border-gray-500 hover:text-white'
+                      }`}
                   >
                     {label}
                   </button>
@@ -290,6 +311,8 @@ export default function TopGearResults({
                       maxDps={maxDps}
                       baseDps={baseDps}
                       isBest={result === results[0] && result.delta > 0}
+                      isSelected={result.name === (selectedResultName || results[0]?.name)}
+                      onSelect={() => setSelectedResultName(result.name)}
                       itemInfoMap={itemInfoMap}
                       enchantInfoMap={enchantInfoMap}
                       gemInfoMap={gemInfoMap}
@@ -307,6 +330,8 @@ export default function TopGearResults({
             itemInfoMap={itemInfoMap}
             enchantInfoMap={enchantInfoMap}
             gemInfoMap={gemInfoMap}
+            selectedResultName={selectedResultName}
+            onSelectResult={setSelectedResultName}
           />
         )}
       </div>
@@ -323,6 +348,8 @@ function RankedResults({
   itemInfoMap,
   enchantInfoMap,
   gemInfoMap,
+  selectedResultName,
+  onSelectResult,
 }: {
   results: TopGearResult[];
   maxDps: number;
@@ -330,6 +357,8 @@ function RankedResults({
   itemInfoMap: Record<number, ItemInfo>;
   enchantInfoMap: Record<number, EnchantInfo>;
   gemInfoMap: Record<number, GemInfo>;
+  selectedResultName: string | null;
+  onSelectResult: (name: string) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
   const visible = expanded ? results : results.slice(0, INITIAL_VISIBLE);
@@ -345,6 +374,8 @@ function RankedResults({
           maxDps={maxDps}
           baseDps={baseDps}
           isBest={idx === 0 && result.delta > 0}
+          isSelected={result.name === (selectedResultName || results[0]?.name)}
+          onSelect={() => onSelectResult(result.name)}
           itemInfoMap={itemInfoMap}
           enchantInfoMap={enchantInfoMap}
           gemInfoMap={gemInfoMap}
@@ -370,6 +401,8 @@ function ResultRow({
   maxDps,
   baseDps,
   isBest,
+  isSelected,
+  onSelect,
   itemInfoMap,
   enchantInfoMap,
   gemInfoMap,
@@ -379,6 +412,8 @@ function ResultRow({
   maxDps: number;
   baseDps: number;
   isBest: boolean;
+  isSelected?: boolean;
+  onSelect?: () => void;
   itemInfoMap: Record<number, ItemInfo>;
   enchantInfoMap: Record<number, EnchantInfo>;
   gemInfoMap: Record<number, GemInfo>;
@@ -410,9 +445,9 @@ function ResultRow({
 
   return (
     <div
-      className={`relative overflow-hidden rounded-lg ${
-        isBest ? 'ring-1 ring-gold/20' : isEquipped ? 'ring-1 ring-white/5' : ''
-      }`}
+      onClick={onSelect}
+      className={`relative overflow-hidden rounded-lg cursor-pointer transition-colors hover:bg-white/[0.04] ${isSelected && !isBest ? 'ring-1 ring-emerald-500/50 bg-emerald-500/[0.04]' : isBest ? `ring-1 ring-gold/30 ${isSelected ? 'bg-gold/[0.05]' : 'bg-transparent'}` : isEquipped ? 'ring-1 ring-white/5' : ''
+        }`}
     >
       <div
         className="absolute inset-y-0 left-0 bg-white/[0.02]"
@@ -467,13 +502,12 @@ function ResultRow({
         </div>
         <div className="flex shrink-0 items-center gap-3">
           <span
-            className={`flex items-center gap-1.5 font-mono text-[13px] tabular-nums ${
-              result.delta > 0
-                ? 'text-emerald-400'
-                : result.delta < 0
-                  ? 'text-red-400'
-                  : 'text-muted'
-            }`}
+            className={`flex items-center gap-1.5 font-mono text-[13px] tabular-nums ${result.delta > 0
+              ? 'text-emerald-400'
+              : result.delta < 0
+                ? 'text-red-400'
+                : 'text-muted'
+              }`}
           >
             <span>
               {result.delta > 0
@@ -517,12 +551,12 @@ function ItemTag({
     item.item_id > 0
       ? getWowheadData(item.bonus_ids, item.ilevel, item.enchant_id, item.gem_id)
       : undefined;
+  const slotName = SLOT_LABELS[item.slot] || item.slot;
 
   return (
     <div
-      className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 ${
-        kept ? 'opacity-40' : 'bg-white/[0.04]'
-      }`}
+      className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 ${kept ? 'opacity-40' : 'bg-white/[0.04]'
+        }`}
     >
       <div className="h-4 w-4 shrink-0 overflow-hidden rounded-sm">
         {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -542,10 +576,15 @@ function ItemTag({
         style={{ color: qc }}
         target="_blank"
         rel="noopener noreferrer"
-        onClick={(e) => e.preventDefault()}
+        onClick={(e) => {
+          e.preventDefault();
+          // Allow parent row handler to naturally select
+          // We don't stop propagation, so click selects the row
+        }}
       >
         {name}
       </a>
+      <span className="text-[9px] text-muted">({slotName})</span>
       {item.upgrade_levels ? (
         <span className="shrink-0 text-[8px] font-bold uppercase tracking-wider text-emerald-400">
           +{item.upgrade_levels}


### PR DESCRIPTION
We can now visualize in the character sheet the select simmed row with highlight on the items and if it is an upgrade or downgrade per item. Also added the slot name near the item itself in the simmed rows combinations to easily differentiate items that has 2 slots like rings and trinkets.
<img width="872" height="852" alt="image" src="https://github.com/user-attachments/assets/6f3c472d-cef3-4a26-910c-85861308aab0" />
<img width="805" height="932" alt="image" src="https://github.com/user-attachments/assets/b8fef8ff-4f81-4611-b174-d3882779c529" />
