### PR TITLE
Add ARM64 (Apple Silicon) support to Docker image build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,6 +40,9 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -48,7 +51,7 @@ jobs:
         with:
           context: .
           file: Dockerfile.standalone
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
The published Docker image only included a linux/amd64 manifest, causing `no matching manifest for linux/arm64/v8` on Apple Silicon.

Add QEMU emulation step and build for both linux/amd64 and linux/arm64 so the image works natively on both architectures.

This will significantly increase build time since it is using emulation in github actions