### PR TITLE
fix(docker): repair server build context and frontend API URL wiring

### DIFF
--- a/backend/server/Dockerfile
+++ b/backend/server/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /build
 COPY Cargo.toml ./
 COPY core/ core/
 COPY server/ server/
+COPY calibration/ calibration/
 COPY migrations/ migrations/
 
 ARG CARGO_FEATURES=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     build:
       context: frontend
       args:
-        - NEXT_PUBLIC_API_URL=${SERVER_IP:-http://localhost:8000}
+        - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:8000}
     ports:
       - "3000:3000"
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,13 +2,14 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
-ARG NEXT_PUBLIC_API_URL=http://localhost:8000
-ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
-
 COPY package.json package-lock.json* ./
 RUN if [ -f package-lock.json ]; then npm ci; else npm install; fi
 
 COPY . .
+
+# Kept below `npm ci` so changing the API URL doesn't invalidate the dependency layer
+ARG NEXT_PUBLIC_API_URL=http://localhost:8000
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 RUN npm run build
 
 FROM node:20-alpine AS runner


### PR DESCRIPTION
- Copy the calibration crate into the builder stage; cargo resolves every workspace member's manifest, so its absence failed the build before compilation started.
- Read the frontend build arg from NEXT_PUBLIC_API_URL instead of SERVER_IP, matching the name documented in docs/self-hosting.md.
- Move the NEXT_PUBLIC_API_URL ARG/ENV below npm ci so changing the API URL no longer invalidates the dependency layer.