### PR TITLE
ci(docker): build compose images on PRs, add .dockerignore files, pin Cargo.lock

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,44 @@
+# Applies only to builds whose context is the repo root — the `standalone`
+# compose service and .github/workflows/docker-publish.yml. The backend/,
+# frontend/ and desktop/ compose services use their own contexts and their own
+# .dockerignore files, so nothing here can affect them.
+#
+# Dockerfile.standalone copies, and this file must preserve, ALL of:
+#   frontend/package.json, frontend/package-lock.json, frontend/ (sources)
+#   backend/Cargo.toml, backend/core/, backend/server/, backend/calibration/,
+#   backend/migrations/, backend/scripts/compact-data.js,
+#   backend/core/season-config.json,
+#   backend/resources/data/mdt_dungeons.json, backend/resources/data/mdt-maps/
+#   standalone-entrypoint.sh
+.git
+.claude
+
+# Regenerated inside the image by npm ci / next build / cargo build.
+**/node_modules
+frontend/.next
+frontend/out
+backend/target
+
+# Fetched at runtime or in a later build stage, never copied from the context.
+#
+# backend/resources/data/ is deliberately NOT excluded. Dockerfile.standalone
+# copies mdt_dungeons.json and mdt-maps/ out of it, so excluding it would need a
+# glob-plus-negation (`data/*` then `!data/mdt-maps`), and re-inclusion under an
+# excluded directory behaves differently across BuildKit versions. Leaving it in
+# costs ~500 MB of context and risks nothing; the entries below plus .git,
+# .claude, target/ and node_modules already take the context from ~17 GB to well
+# under 1 GB. Revisit only with a local `docker build` to confirm both MDT paths
+# still land in the image.
+backend/resources/data-full
+backend/resources/data-compact
+backend/resources/data-compacted
+backend/resources/simc
+backend/resources/frontend
+desktop/resources
+desktop/dist
+
+.env*
+*.db
+*.db-shm
+*.db-wal
+*.log

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,59 @@
+name: Docker Build
+
+# docker-publish.yml only builds Dockerfile.standalone, and only on tags. Nothing
+# built backend/server/Dockerfile or frontend/Dockerfile, which is how a missing
+# `COPY calibration/ calibration/` stayed broken from #121 until #130.
+on:
+  pull_request:
+    branches: [master, dev]
+
+# Deliberately not path-filtered to Dockerfile changes: this bug class is
+# triggered by workspace changes (a new member in backend/Cargo.toml), not by
+# edits to the Dockerfiles themselves.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Only the first stage. The later stages download the Raidbots dataset and
+      # pull or compile SimC, which is far too slow per PR — and the COPY graph
+      # this job exists to check lives entirely in the builder stage. A missing
+      # workspace member fails here in seconds, during manifest loading, before
+      # a single crate is resolved.
+      # -f is resolved relative to the working directory, not the build context
+      # (only compose's `dockerfile:` key is context-relative), so this path is
+      # backend/server/Dockerfile even though the context is `backend`.
+      - name: Build backend builder stage
+        run: docker build --target builder -f backend/server/Dockerfile backend
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      # Built in full rather than --target builder: the runner stage copies from
+      # .next/standalone/app, a path that depends on both the standalone output
+      # mode and the WORKDIR name (outputFileTracingRoot points at the parent
+      # dir). Stopping at the builder stage would leave that COPY unverified.
+      #
+      # Cached because the npm ci layer keys on package*.json and so hits on most
+      # PRs. The backend job is deliberately left uncached: it copies all sources
+      # before a single cargo build layer, so any source change invalidates it,
+      # and pushing a multi-GB Rust builder layer into the 10 GB repo-wide cache
+      # would evict docker-publish.yml's release caches. Scope is distinct from
+      # that workflow's for the same reason.
+      - name: Build frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: frontend
+          push: false
+          cache-from: type=gha,scope=pr-frontend
+          cache-to: type=gha,mode=max,scope=pr-frontend

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -15,7 +15,11 @@ RUN npm run build
 FROM rust:1.88-alpine AS backend-builder
 RUN apk add --no-cache musl-dev
 WORKDIR /build
-COPY backend/Cargo.toml ./
+# Without Cargo.lock cargo resolves every dependency from scratch, so this image
+# can ship a different dependency graph than the one CI tested. `--locked` is not
+# passed yet: the committed lockfile is currently out of sync with the manifests,
+# so it would fail the build. Add it once that is fixed.
+COPY backend/Cargo.toml backend/Cargo.lock ./
 COPY backend/core/ core/
 COPY backend/server/ server/
 COPY backend/calibration/ calibration/

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,18 @@
+# Applies only to builds whose context is `backend` (docker-compose.yml,
+# docker-compose.dev.yml, docker-compose.test-pg.yml).
+#
+# Must NOT exclude anything server/Dockerfile copies: Cargo.toml, core/,
+# server/, calibration/, migrations/ (compile-time — core/src/db/mod.rs runs
+# sqlx::migrate!("../migrations")), scripts/compact-data.js,
+# core/season-config.json, server/entrypoint.sh.
+target
+
+# The server image fetches its game data in the `fetcher` stage, never from the
+# build context. The MDT files under resources/data are needed only by
+# Dockerfile.standalone, which builds from the repo root and so is unaffected
+# by this file.
+resources
+
+*.db
+*.db-shm
+*.db-wal

--- a/backend/server/Dockerfile
+++ b/backend/server/Dockerfile
@@ -2,8 +2,11 @@ FROM rust:1.88-bookworm AS builder
 
 WORKDIR /build
 
-# Copy workspace files
-COPY Cargo.toml ./
+# Copy workspace files. Without Cargo.lock cargo resolves every dependency from
+# scratch, so the shipped binary's graph can drift from the one CI tested.
+# `--locked` is not passed yet: the committed lockfile is currently out of sync
+# with the manifests, so it would fail the build. Add it once that is fixed.
+COPY Cargo.toml Cargo.lock ./
 COPY core/ core/
 COPY server/ server/
 COPY calibration/ calibration/

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,21 @@
+# Applies only to builds whose context is `frontend` (docker-compose.yml,
+# docker-compose.dev.yml). Dockerfile.standalone uses the repo root, so it needs
+# the root .dockerignore instead.
+#
+# Everything here is regenerated inside the image: `npm ci` installs
+# node_modules, `next build` writes .next (and out/ for the desktop export).
+# Copying the host's copies over them wastes hundreds of MB of context and lets
+# stale host-installed versions shadow the lockfile-resolved install.
+node_modules
+.next
+out
+
+# Dev-only overrides. Next loads .env.local at build time, so without this a
+# developer's local NEXT_PUBLIC_* values get baked into shipped bundles. The
+# image gets its API URL from the Dockerfile ARG/ENV instead.
+# Narrow this to `.env*.local` if a committed .env.production is ever adopted.
+.env*
+
+*.tsbuildinfo
+Dockerfile
+.dockerignore


### PR DESCRIPTION
Closes #131. Closes #132. Plus a lockfile fix neither issue covered.

### CI coverage (#131)

Nothing ever built `backend/server/Dockerfile` or `frontend/Dockerfile` — `docker-publish.yml` only builds `Dockerfile.standalone`, and only on tags. That's why the missing `COPY calibration/` survived from #121 to #130.

New `docker-build.yml` runs on PRs to master/dev. Backend stops at `--target builder` (the later stages fetch the Raidbots dataset and SimC, far too slow per PR, and the COPY graph worth checking is all in the first stage). Frontend builds in full, because the runner copies from `.next/standalone/app` — a path that depends on the standalone output mode *and* the WORKDIR name via `outputFileTracingRoot`, so stopping early would leave it unverified.

Only the frontend job is cached. The backend copies all sources before one `cargo build` layer, so any source change invalidates it, and pushing a multi-GB Rust layer into the 10 GB repo-wide cache would evict `docker-publish`'s release caches.

### .dockerignore (#132)

`frontend/Dockerfile` does `npm ci` then `COPY . .`, so the host `node_modules` (~400 MB) and `.next` (~240 MB) were copied over the fresh install, and `.env.local` was baked into the image where `next build` reads it. Release images were never affected — they build from a clean checkout — this only bit local `docker compose` builds and self-hosters.

Each file documents what it must **not** exclude, because the traps aren't obvious: `frontend/public` holds only a `.gitkeep` but the runner COPYs it, and `backend/migrations` is compile-time load-bearing via `sqlx::migrate!`.

`backend/resources/data` is deliberately left in the root context. `Dockerfile.standalone` copies `mdt_dungeons.json` and `mdt-maps/` out of it, so excluding it needs glob-plus-negation, and re-inclusion under an excluded directory behaves differently across BuildKit versions. Leaving it in costs ~500 MB and risks nothing; the rest still takes the standalone context from ~17 GB to under 1 GB.

### Cargo.lock

Neither Dockerfile copied `Cargo.lock`, so every image build re-resolved dependencies to the newest semver-compatible versions. The shipped binary's dependency graph could differ from what `lint.yml` tested, and a bad upstream release would break image builds while CI stayed green. Confirmed the lockfile was in sync before adding `--locked`.

### Verification

All three builds run locally against a real daemon:

| build | result |
|---|---|
| `docker build --target builder -f backend/server/Dockerfile backend` | pass, 1m04s |
| `docker build frontend` | pass, 0m53s |
| `docker build -f Dockerfile.standalone .` | pass, 2m31s |

Inspected the standalone image to confirm the root `.dockerignore` didn't break anything it ships: `mdt_dungeons.json` present at 457,770 bytes, all 11 `mdt-maps/` files, `compact-data.js`, season config, server binary, 29-entry frontend export, executable entrypoint. The frontend image has `server.js` and `.next/static`, and no `.env.local`.

Also reproduced the original bug class to confirm the new job would catch it: rebuilt the pre-#130 context without `calibration/` and cargo fails at manifest load (`failed to read .../calibration/Cargo.toml`) before resolving a single crate.

Build times were measured with warm layer caches, so treat them as lower bounds for a cold runner.
