### PR TITLE
style: apply cargo fmt and prettier

### DIFF
--- a/backend/core/src/compute/registry.rs
+++ b/backend/core/src/compute/registry.rs
@@ -139,10 +139,8 @@ fn smart_default(
     avail: &ProviderAvailability,
     est: &WorkloadEstimate,
 ) -> &'static str {
-    let big_job = matches!(
-        sim_type,
-        "top_gear" | "droptimizer" | "upgrade_compare"
-    ) && est.combo_count >= 50;
+    let big_job =
+        matches!(sim_type, "top_gear" | "droptimizer" | "upgrade_compare") && est.combo_count >= 50;
     if big_job {
         avail.first_configured_remote().unwrap_or("local")
     } else {

--- a/backend/core/src/db/roster_repo.rs
+++ b/backend/core/src/db/roster_repo.rs
@@ -151,12 +151,13 @@ impl RosterRepo {
         let now = chrono::Utc::now().to_rfc3339();
         match &self.backend {
             RosterBackend::Database(pool) => {
-                let result = sqlx::query("UPDATE rosters SET name = $1, updated_at = $2 WHERE id = $3")
-                    .bind(name)
-                    .bind(&now)
-                    .bind(id)
-                    .execute(pool)
-                    .await?;
+                let result =
+                    sqlx::query("UPDATE rosters SET name = $1, updated_at = $2 WHERE id = $3")
+                        .bind(name)
+                        .bind(&now)
+                        .bind(id)
+                        .execute(pool)
+                        .await?;
                 Ok(result.rows_affected() > 0)
             }
             RosterBackend::Memory(memory) => {
@@ -394,8 +395,30 @@ mod tests {
     async fn upsert_member_is_idempotent_on_name_realm() {
         let repo = RosterRepo::new_memory();
         let r = repo.create("T", "eu").await.unwrap();
-        repo.upsert_member(&r.id, "Thrall", "Draenor", "shaman", "enhancement", "sim1", "ok", 480).await.unwrap();
-        repo.upsert_member(&r.id, "Thrall", "Draenor", "shaman", "enhancement", "sim2", "ok", 489).await.unwrap();
+        repo.upsert_member(
+            &r.id,
+            "Thrall",
+            "Draenor",
+            "shaman",
+            "enhancement",
+            "sim1",
+            "ok",
+            480,
+        )
+        .await
+        .unwrap();
+        repo.upsert_member(
+            &r.id,
+            "Thrall",
+            "Draenor",
+            "shaman",
+            "enhancement",
+            "sim2",
+            "ok",
+            489,
+        )
+        .await
+        .unwrap();
         let members = repo.list_members(&r.id).await.unwrap();
         assert_eq!(members.len(), 1);
         assert_eq!(members[0].source_simc, "sim2");
@@ -406,7 +429,9 @@ mod tests {
     async fn delete_roster_removes_members() {
         let repo = RosterRepo::new_memory();
         let r = repo.create("T", "us").await.unwrap();
-        repo.upsert_member(&r.id, "A", "R", "mage", "frost", "s", "ok", 0).await.unwrap();
+        repo.upsert_member(&r.id, "A", "R", "mage", "frost", "s", "ok", 0)
+            .await
+            .unwrap();
         assert!(repo.delete(&r.id).await.unwrap());
         assert!(repo.list_members(&r.id).await.unwrap().is_empty());
     }

--- a/backend/core/src/db/roster_run_repo.rs
+++ b/backend/core/src/db/roster_run_repo.rs
@@ -285,7 +285,10 @@ mod tests {
     #[tokio::test]
     async fn create_run_then_get_and_map_jobs() {
         let repo = RosterRunRepo::new_memory();
-        let run = repo.create_run("roster1", 1234, "heroic", "batch1").await.unwrap();
+        let run = repo
+            .create_run("roster1", 1234, "heroic", "batch1")
+            .await
+            .unwrap();
         assert_eq!(run.status, "running");
         assert_eq!(run.instance_id, 1234);
         assert!(run.report_json.is_none());
@@ -313,14 +316,23 @@ mod tests {
         let repo = RosterRunRepo::new_memory();
         let run = repo.create_run("r", 1, "heroic", "b").await.unwrap();
         repo.set_status(&run.id, "failed").await.unwrap();
-        assert_eq!(repo.get_run(&run.id).await.unwrap().unwrap().status, "failed");
+        assert_eq!(
+            repo.get_run(&run.id).await.unwrap().unwrap().status,
+            "failed"
+        );
     }
 
     #[tokio::test]
     async fn list_runs_returns_roster_runs_newest_first_without_report() {
         let repo = RosterRunRepo::new_memory();
-        let r1 = repo.create_run("roster1", 100, "heroic", "b1").await.unwrap();
-        let r2 = repo.create_run("roster1", 200, "mythic", "b2").await.unwrap();
+        let r1 = repo
+            .create_run("roster1", 100, "heroic", "b1")
+            .await
+            .unwrap();
+        let r2 = repo
+            .create_run("roster1", 200, "mythic", "b2")
+            .await
+            .unwrap();
         repo.create_run("other", 300, "heroic", "b3").await.unwrap();
         repo.set_report(&r2.id, "{\"big\":true}").await.unwrap();
         let runs = repo.list_runs("roster1").await.unwrap();

--- a/backend/core/src/game_data.rs
+++ b/backend/core/src/game_data.rs
@@ -489,7 +489,10 @@ fn build_catalyst_variant(item: &Value, class_id: u64, inv_type: u64) -> Option<
     obj.insert("name".to_string(), Value::String(tier.name.clone()));
     obj.insert("icon".to_string(), Value::String(tier.icon.clone()));
     obj.insert("is_catalyst".to_string(), Value::Bool(true));
-    obj.insert("source_item_id".to_string(), serde_json::json!(source_item_id));
+    obj.insert(
+        "source_item_id".to_string(),
+        serde_json::json!(source_item_id),
+    );
     // The tier piece is not embellished even if the source drop was; drop the
     // stale flag so it doesn't show the badge or count against the 2/2 limit.
     obj.remove("embellished");
@@ -525,7 +528,8 @@ pub fn add_drop_variants(
         let mut variants: Vec<Value> = Vec::new();
         // Many source items in a slot convert to the SAME class tier piece; keep
         // only the first so we don't emit duplicate identical catalyst rows/sims.
-        let mut catalyst_tier_seen: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        let mut catalyst_tier_seen: std::collections::HashSet<u64> =
+            std::collections::HashSet::new();
         for item in arr.iter() {
             let inv_type = item
                 .get("inventory_type")
@@ -734,7 +738,11 @@ mod variant_tests {
         // 1307 = The Voidspire, a current raid with weapons + tier armor.
         let mut map = get_instance_drops(1307, Some("mage"), Some("frost"))
             .expect("Voidspire should have mage/frost drops");
-        let before: usize = map.values().filter_map(|v| v.as_array()).map(|a| a.len()).sum();
+        let before: usize = map
+            .values()
+            .filter_map(|v| v.as_array())
+            .map(|a| a.len())
+            .sum();
 
         add_drop_variants(&mut map, Some("mage"), true, true);
 
@@ -750,7 +758,11 @@ mod variant_tests {
                 }
             }
         }
-        let after: usize = map.values().filter_map(|v| v.as_array()).map(|a| a.len()).sum();
+        let after: usize = map
+            .values()
+            .filter_map(|v| v.as_array())
+            .map(|a| a.len())
+            .sum();
         assert!(vf_count > 0, "expected at least one void-forge sibling");
         assert!(cat_count > 0, "expected at least one catalyst sibling");
         assert_eq!(after, before + vf_count + cat_count);
@@ -762,6 +774,9 @@ mod variant_tests {
         let map = get_instance_drops(1307, Some("mage"), Some("frost")).unwrap();
         let mut copy = map.clone();
         add_drop_variants(&mut copy, Some("mage"), false, false);
-        assert_eq!(copy, map, "roster path (both false) must leave map unchanged");
+        assert_eq!(
+            copy, map,
+            "roster path (both false) must leave map unchanged"
+        );
     }
 }

--- a/backend/core/src/profileset_generator/base_profile.rs
+++ b/backend/core/src/profileset_generator/base_profile.rs
@@ -150,7 +150,9 @@ raid_events+=/pull,pull=1,enemies=\"x_1\":100";
         assert_eq!(tal_a, tal_b, "talents unaffected by route lines");
         assert_eq!(spec_a, spec_b, "spec unaffected by route lines");
         assert!(non_gear_b.iter().any(|l| l == "fight_style=DungeonRoute"));
-        assert!(non_gear_b.iter().any(|l| l.starts_with("raid_events+=/pull")));
+        assert!(non_gear_b
+            .iter()
+            .any(|l| l.starts_with("raid_events+=/pull")));
     }
 
     #[test]

--- a/backend/core/src/profileset_generator/droptimizer.rs
+++ b/backend/core/src/profileset_generator/droptimizer.rs
@@ -219,7 +219,11 @@ pub(super) fn generate_droptimizer_input(
                     .collect();
                 if let Some(&first) = gems.first() {
                     applied_gem = first;
-                    let gem_str = gems.iter().map(u64::to_string).collect::<Vec<_>>().join("/");
+                    let gem_str = gems
+                        .iter()
+                        .map(u64::to_string)
+                        .collect::<Vec<_>>()
+                        .join("/");
                     simc_str.push_str(&format!(",gem_id={}", gem_str));
                 }
             }

--- a/backend/core/src/roster/armory_to_simc.rs
+++ b/backend/core/src/roster/armory_to_simc.rs
@@ -147,7 +147,11 @@ pub fn armory_to_simc(armory: &Value) -> String {
     let mut lines: Vec<String> = Vec::new();
 
     if let Some(class) = class {
-        lines.push(format!("{}=\"{}\"", simc_class_token(class), title_case(name)));
+        lines.push(format!(
+            "{}=\"{}\"",
+            simc_class_token(class),
+            title_case(name)
+        ));
     }
     lines.push(format!("level={level}"));
     if let Some(race) = race {
@@ -224,7 +228,10 @@ mod tests {
             "talents": { "loadoutCode": "CAEAMhlVtghLZL4RZzExaQoBYZGGLzMzsgZmYmZGzMzMziZmZmZMzsMTDLDAwMDWmZaDAAWAAAA2AYbZMjZwsxMmZsAAAwMbzMYGGDAA" }
         });
         let simc = armory_to_simc(&armory);
-        assert!(simc.lines().any(|l| l == "level=70"), "expected level=70:\n{simc}");
+        assert!(
+            simc.lines().any(|l| l == "level=70"),
+            "expected level=70:\n{simc}"
+        );
     }
 
     #[test]
@@ -236,8 +243,14 @@ mod tests {
             "talents": { "loadoutCode": "CAEAMhlVtghLZL4RZzExaQoBYZGGLzMzsgZmYmZGzMzMziZmZmZMzsMTDLDAwMDWmZaDAAWAAAA2AYbZMjZwsxMmZsAAAwMbzMYGGDAA" }
         });
         let simc = armory_to_simc(&armory);
-        assert!(simc.lines().any(|l| l == "level=90"), "expected level=90 fallback:\n{simc}");
-        assert!(!simc.contains("level=80"), "must not hardcode level=80:\n{simc}");
+        assert!(
+            simc.lines().any(|l| l == "level=90"),
+            "expected level=90 fallback:\n{simc}"
+        );
+        assert!(
+            !simc.contains("level=80"),
+            "must not hardcode level=80:\n{simc}"
+        );
     }
 
     #[test]
@@ -255,16 +268,31 @@ mod tests {
             ]}
         });
         let simc = armory_to_simc(&armory);
-        let head = simc.lines().find(|l| l.starts_with("head=")).expect("head line");
+        let head = simc
+            .lines()
+            .find(|l| l.starts_with("head="))
+            .expect("head line");
         assert!(head.contains("id=249988"), "{head}");
-        assert!(head.contains("bonus_id=43/13440/13338"), "bonus ids:\n{head}");
+        assert!(
+            head.contains("bonus_id=43/13440/13338"),
+            "bonus ids:\n{head}"
+        );
         assert!(head.contains("gem_id=240898"), "gem from object:\n{head}");
         // bonus ids encode the item level, so no explicit ilevel on bonus'd items
-        assert!(!head.contains("ilevel="), "ilevel should be omitted when bonus present:\n{head}");
+        assert!(
+            !head.contains("ilevel="),
+            "ilevel should be omitted when bonus present:\n{head}"
+        );
         // enchants array -> enchant_id from the first entry's `id`
-        assert!(head.contains("enchant_id=8017"), "enchant id from enchants array:\n{head}");
+        assert!(
+            head.contains("enchant_id=8017"),
+            "enchant id from enchants array:\n{head}"
+        );
         // race emitted
-        assert!(simc.lines().any(|l| l == "race=troll"), "race line:\n{simc}");
+        assert!(
+            simc.lines().any(|l| l == "race=troll"),
+            "race line:\n{simc}"
+        );
     }
 
     #[test]
@@ -276,13 +304,15 @@ mod tests {
         assert_eq!(simc_class_token("shaman"), "shaman");
     }
 
-
     #[test]
     fn race_strips_apostrophe_and_spaces() {
         // "Mag'har Orc" must become `maghar_orc` (SimC rejects the apostrophe form).
         let armory = json!({ "character": { "name": "x", "realm": "r", "race": "Mag'har Orc" } });
         let simc = armory_to_simc(&armory);
-        assert!(simc.lines().any(|l| l == "race=maghar_orc"), "race line:\n{simc}");
+        assert!(
+            simc.lines().any(|l| l == "race=maghar_orc"),
+            "race line:\n{simc}"
+        );
         assert!(!simc.contains('\''), "no apostrophe in output:\n{simc}");
     }
 
@@ -295,7 +325,10 @@ mod tests {
         });
         let simc = armory_to_simc(&armory);
         let head = simc.lines().find(|l| l.starts_with("head=")).unwrap();
-        assert!(head.contains("ilevel=600"), "ilevel fallback when no bonus:\n{head}");
+        assert!(
+            head.contains("ilevel=600"),
+            "ilevel fallback when no bonus:\n{head}"
+        );
         assert!(!head.contains("bonus_id="), "{head}");
     }
 
@@ -332,7 +365,10 @@ mod tests {
             "gear": { "items": [ { "slot": "HEAD", "itemId": 222, "itemLevel": 600 } ] }
         });
         let simc = armory_to_simc(&armory);
-        assert!(!simc.contains("spec="), "no spec for missing loadout:\n{simc}");
+        assert!(
+            !simc.contains("spec="),
+            "no spec for missing loadout:\n{simc}"
+        );
         let parsed = crate::addon_parser::parse_simc_input(&simc);
         assert_eq!(parsed.character.class_name, None);
         assert!(parsed.items.iter().any(|i| i.raw_slot == "head"));

--- a/backend/core/src/roster/drop_items.rs
+++ b/backend/core/src/roster/drop_items.rs
@@ -1,5 +1,5 @@
-use serde_json::{json, Value};
 use crate::game_data;
+use serde_json::{json, Value};
 
 /// Build droptimizer `drop_items` for one character: every eligible drop in the
 /// instance at the chosen difficulty's item level + bonus id.
@@ -74,10 +74,7 @@ fn resolve_upgrade(
         });
     match entry {
         Some(e) => {
-            let ilvl = e
-                .get("ilvl")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(base_ilvl);
+            let ilvl = e.get("ilvl").and_then(|v| v.as_u64()).unwrap_or(base_ilvl);
             let bonus = e
                 .get("bonus_id")
                 .and_then(|v| v.as_u64())
@@ -102,7 +99,9 @@ pub fn drop_items_from_slots(
 ) -> Vec<Value> {
     let mut out = Vec::new();
     for items in by_slot.values() {
-        let Some(arr) = items.as_array() else { continue };
+        let Some(arr) = items.as_array() else {
+            continue;
+        };
         for item in arr {
             let item_id = item.get("item_id").and_then(|v| v.as_u64()).unwrap_or(0);
             if item_id == 0 {
@@ -192,7 +191,9 @@ mod tests {
         assert_eq!(r.get("item_id").and_then(|v| v.as_u64()), Some(12345));
         assert_eq!(r.get("ilevel").and_then(|v| v.as_u64()), Some(639));
         assert_eq!(
-            r.get("bonus_ids").and_then(|v| v.as_array()).map(|a| a.iter().filter_map(|b| b.as_u64()).collect::<Vec<_>>()),
+            r.get("bonus_ids")
+                .and_then(|v| v.as_array())
+                .map(|a| a.iter().filter_map(|b| b.as_u64()).collect::<Vec<_>>()),
             Some(vec![10421u64])
         );
     }
@@ -438,7 +439,10 @@ mod tests {
         let r = &result[0];
         assert_eq!(r.get("item_id").and_then(|v| v.as_u64()), Some(5000));
         assert_eq!(r.get("is_catalyst").and_then(|v| v.as_bool()), Some(true));
-        assert_eq!(r.get("source_item_id").and_then(|v| v.as_u64()), Some(12345));
+        assert_eq!(
+            r.get("source_item_id").and_then(|v| v.as_u64()),
+            Some(12345)
+        );
         let bonus_ids: Vec<u64> = r
             .get("bonus_ids")
             .and_then(|v| v.as_array())
@@ -502,20 +506,45 @@ mod tests {
         // ilvls per difficulty (LFR 259 / Mythic 298) with NO upgrade track.
         let tracks = game_data::get_upgrade_tracks();
         let lfr = build_drop_items(1305, "lfr", "mage", "frost", 0, &[], &tracks, false, false);
-        let mythic = build_drop_items(1305, "mythic", "mage", "frost", 0, &[], &tracks, false, false);
+        let mythic = build_drop_items(
+            1305,
+            "mythic",
+            "mage",
+            "frost",
+            0,
+            &[],
+            &tracks,
+            false,
+            false,
+        );
         assert!(!lfr.is_empty(), "expected Sporefall drops for mage/frost");
         assert!(
-            lfr.iter().all(|d| d.get("ilevel").and_then(|v| v.as_u64()) == Some(259)),
+            lfr.iter()
+                .all(|d| d.get("ilevel").and_then(|v| v.as_u64()) == Some(259)),
             "LFR Sporefall drops must all be ilvl 259"
         );
         assert!(
-            mythic.iter().all(|d| d.get("ilevel").and_then(|v| v.as_u64()) == Some(298)),
+            mythic
+                .iter()
+                .all(|d| d.get("ilevel").and_then(|v| v.as_u64()) == Some(298)),
             "Mythic Sporefall drops must all be ilvl 298"
         );
         // No upgrade track: a max upgrade level must NOT change the mythic ilvl.
-        let mythic_up = build_drop_items(1305, "mythic", "mage", "frost", 8, &[], &tracks, false, false);
+        let mythic_up = build_drop_items(
+            1305,
+            "mythic",
+            "mage",
+            "frost",
+            8,
+            &[],
+            &tracks,
+            false,
+            false,
+        );
         assert!(
-            mythic_up.iter().all(|d| d.get("ilevel").and_then(|v| v.as_u64()) == Some(298)),
+            mythic_up
+                .iter()
+                .all(|d| d.get("ilevel").and_then(|v| v.as_u64()) == Some(298)),
             "upgrade level must be a no-op for fixed-difficulty raids"
         );
     }

--- a/backend/core/src/roster/report.rs
+++ b/backend/core/src/roster/report.rs
@@ -126,7 +126,10 @@ pub fn aggregate_report(
             if combo_name.starts_with("Currently Equipped") {
                 continue;
             }
-            let Some(item) = combo.get("items").and_then(|v| v.as_array()).and_then(|a| a.first())
+            let Some(item) = combo
+                .get("items")
+                .and_then(|v| v.as_array())
+                .and_then(|a| a.first())
             else {
                 continue;
             };
@@ -149,7 +152,10 @@ pub fn aggregate_report(
             let uid = if is_void_forge {
                 format!("{item_id}:vf")
             } else if is_catalyst {
-                let source = item.get("source_item_id").and_then(|v| v.as_u64()).unwrap_or(0);
+                let source = item
+                    .get("source_item_id")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0);
                 format!("{item_id}:cat:{source}")
             } else {
                 item_id.to_string()
@@ -211,7 +217,11 @@ pub fn aggregate_report(
                 .iter()
                 .map(|(member_id, (dps, delta))| {
                     let base = member_base.get(member_id.as_str()).copied().unwrap_or(0.0);
-                    let upgrade_pct = if base > 0.0 { delta / base * 100.0 } else { 0.0 };
+                    let upgrade_pct = if base > 0.0 {
+                        delta / base * 100.0
+                    } else {
+                        0.0
+                    };
                     ItemResult {
                         member_id: member_id.clone(),
                         dps: *dps,
@@ -301,7 +311,10 @@ mod tests {
             "equipped baseline item leaked into report: {:?}",
             report.items.iter().map(|i| i.item_id).collect::<Vec<_>>()
         );
-        assert!(report.items.iter().any(|i| i.item_id == 111), "drop should be present");
+        assert!(
+            report.items.iter().any(|i| i.item_id == 111),
+            "drop should be present"
+        );
         assert_eq!(report.items.len(), 1);
     }
 
@@ -383,8 +396,16 @@ mod tests {
             })),
         )];
         let report = aggregate_report("r", 1, "heroic", &inputs);
-        assert_eq!(report.items.len(), 2, "base + void forge must be separate rows");
-        let vf = report.items.iter().find(|i| i.is_void_forge).expect("vf row");
+        assert_eq!(
+            report.items.len(),
+            2,
+            "base + void forge must be separate rows"
+        );
+        let vf = report
+            .items
+            .iter()
+            .find(|i| i.is_void_forge)
+            .expect("vf row");
         assert_eq!(vf.item_id, 111);
         assert_eq!(vf.uid, "111:vf");
         let base = report

--- a/backend/core/src/server/helpers.rs
+++ b/backend/core/src/server/helpers.rs
@@ -1089,7 +1089,10 @@ mod tests {
         let combo_idx = out.find("### Combo 1").expect("combo marker present");
         let gear_idx = out.find("hands=,id=2").expect("equipped gear present");
         assert!(route_idx > combo_idx, "route must come after ### Combo 1");
-        assert!(route_idx > gear_idx, "route must come after the equipped gear");
+        assert!(
+            route_idx > gear_idx,
+            "route must come after the equipped gear"
+        );
         // Route is emitted as its own trailing block, not a pre-combo "# Custom APL".
         assert!(out.contains("# Dungeon Route"));
         assert!(

--- a/backend/core/src/server/roster_handlers.rs
+++ b/backend/core/src/server/roster_handlers.rs
@@ -96,9 +96,15 @@ pub(super) async fn import_pairs(
                 let parsed = crate::addon_parser::parse_simc_input(&simc);
                 let class = parsed.character.class_name.unwrap_or_default();
                 let spec = parsed.character.spec.unwrap_or_default();
-                let status = if class.is_empty() { "armory_failed" } else { "ok" };
-                repo.upsert_member(roster_id, name, realm, &class, &spec, &simc, status, item_level)
-                    .await?;
+                let status = if class.is_empty() {
+                    "armory_failed"
+                } else {
+                    "ok"
+                };
+                repo.upsert_member(
+                    roster_id, name, realm, &class, &spec, &simc, status, item_level,
+                )
+                .await?;
             }
             Err(ArmoryError::NotFound) => {
                 repo.upsert_member(roster_id, name, realm, "", "", "", "not_found", 0)
@@ -137,10 +143,20 @@ pub(super) async fn import_members(
     let roster = match repo.get(&roster_id).await {
         Ok(Some(r)) => r,
         Ok(None) => return HttpResponse::NotFound().json(json!({"detail": "Roster not found"})),
-        Err(e) => return HttpResponse::InternalServerError().json(json!({"detail": e.to_string()})),
+        Err(e) => {
+            return HttpResponse::InternalServerError().json(json!({"detail": e.to_string()}))
+        }
     };
     let client = HttpArmoryClient::new();
-    match run_import(&client, repo.get_ref(), &roster_id, &roster.region, &req.text).await {
+    match run_import(
+        &client,
+        repo.get_ref(),
+        &roster_id,
+        &roster.region,
+        &req.text,
+    )
+    .await
+    {
         Ok(members) => HttpResponse::Ok().json(members),
         Err(e) => HttpResponse::InternalServerError().json(json!({"detail": e.to_string()})),
     }
@@ -156,11 +172,15 @@ pub(super) async fn refresh_roster(
     let roster = match repo.get(&roster_id).await {
         Ok(Some(r)) => r,
         Ok(None) => return HttpResponse::NotFound().json(json!({"detail": "Roster not found"})),
-        Err(e) => return HttpResponse::InternalServerError().json(json!({"detail": e.to_string()})),
+        Err(e) => {
+            return HttpResponse::InternalServerError().json(json!({"detail": e.to_string()}))
+        }
     };
     let members = match repo.list_members(&roster_id).await {
         Ok(m) => m,
-        Err(e) => return HttpResponse::InternalServerError().json(json!({"detail": e.to_string()})),
+        Err(e) => {
+            return HttpResponse::InternalServerError().json(json!({"detail": e.to_string()}))
+        }
     };
     let pairs: Vec<(String, String)> = members
         .iter()
@@ -183,11 +203,15 @@ pub(super) async fn refresh_member(
     let roster = match repo.get(&roster_id).await {
         Ok(Some(r)) => r,
         Ok(None) => return HttpResponse::NotFound().json(json!({"detail": "Roster not found"})),
-        Err(e) => return HttpResponse::InternalServerError().json(json!({"detail": e.to_string()})),
+        Err(e) => {
+            return HttpResponse::InternalServerError().json(json!({"detail": e.to_string()}))
+        }
     };
     let members = match repo.list_members(&roster_id).await {
         Ok(m) => m,
-        Err(e) => return HttpResponse::InternalServerError().json(json!({"detail": e.to_string()})),
+        Err(e) => {
+            return HttpResponse::InternalServerError().json(json!({"detail": e.to_string()}))
+        }
     };
     let Some(member) = members.iter().find(|m| m.id == member_id) else {
         return HttpResponse::NotFound().json(json!({"detail": "Member not found"}));

--- a/backend/core/src/server/roster_run_handlers.rs
+++ b/backend/core/src/server/roster_run_handlers.rs
@@ -216,7 +216,12 @@ pub(super) async fn get_run(
         fetched.into_iter().map(|j| (j.id.clone(), j)).collect();
     let jobs: Vec<(String, Option<crate::models::Job>)> = mappings
         .iter()
-        .map(|mapping| (mapping.member_id.clone(), by_id.get(&mapping.job_id).cloned()))
+        .map(|mapping| {
+            (
+                mapping.member_id.clone(),
+                by_id.get(&mapping.job_id).cloned(),
+            )
+        })
         .collect();
 
     let total = mappings.len();

--- a/backend/core/src/simc_runner.rs
+++ b/backend/core/src/simc_runner.rs
@@ -1878,11 +1878,23 @@ mod tests {
         // The user's enabled buff is emitted (it would be absent under the old
         // skip-for-dungeon behavior) and lands after the route's fight_style line.
         assert!(out.contains("override.bloodlust=1"));
-        let fs_idx = out.find("fight_style=DungeonRoute").expect("route fight_style");
-        let user_lust = out.rfind("override.bloodlust=1").expect("user bloodlust override");
-        let user_ai = out.rfind("override.arcane_intellect=0").expect("user AI override");
-        assert!(user_lust > fs_idx, "user override must come after fight_style");
-        assert!(user_ai > fs_idx, "user override must come after fight_style");
+        let fs_idx = out
+            .find("fight_style=DungeonRoute")
+            .expect("route fight_style");
+        let user_lust = out
+            .rfind("override.bloodlust=1")
+            .expect("user bloodlust override");
+        let user_ai = out
+            .rfind("override.arcane_intellect=0")
+            .expect("user AI override");
+        assert!(
+            user_lust > fs_idx,
+            "user override must come after fight_style"
+        );
+        assert!(
+            user_ai > fs_idx,
+            "user override must come after fight_style"
+        );
         // fight_style is not re-emitted for dungeon routes (it lives in the block).
         assert_eq!(out.matches("fight_style=").count(), 1);
     }

--- a/frontend/src/app/components/raid-roster/ItemCentricView.tsx
+++ b/frontend/src/app/components/raid-roster/ItemCentricView.tsx
@@ -13,13 +13,7 @@ interface Props {
   itemInfo: Record<number, ItemInfo>;
 }
 
-function ResultRow({
-  result,
-  playerName,
-}: {
-  result: ReportItemResult;
-  playerName: string;
-}) {
+function ResultRow({ result, playerName }: { result: ReportItemResult; playerName: string }) {
   const pct = result.upgrade_pct;
   const isUpgrade = pct > 0;
   const isDowngrade = pct < 0;
@@ -49,7 +43,8 @@ function ResultRow({
         />
       </div>
       <span className={`w-14 shrink-0 text-right text-sm font-bold tabular-nums ${textColor}`}>
-        {sign}{pct.toFixed(1)}%
+        {sign}
+        {pct.toFixed(1)}%
       </span>
     </div>
   );

--- a/frontend/src/app/components/raid-roster/MatrixView.tsx
+++ b/frontend/src/app/components/raid-roster/MatrixView.tsx
@@ -7,9 +7,9 @@ import { heatClasses } from './reportTypes';
 import VariantBadges from '../loot/VariantBadges';
 
 interface Props {
-  items: ReportItem[];                                  // filtered + sorted by container
-  players: ReportPlayer[];                              // column order (filtered)
-  lookup: Map<string, Map<string, ReportItemResult>>;   // uid -> member_id -> result
+  items: ReportItem[]; // filtered + sorted by container
+  players: ReportPlayer[]; // column order (filtered)
+  lookup: Map<string, Map<string, ReportItemResult>>; // uid -> member_id -> result
   itemInfo: Record<number, ItemInfo>;
 }
 
@@ -65,10 +65,7 @@ export default function MatrixView({ items, players, lookup, itemInfo }: Props) 
                 alt={displayName}
                 className="h-6 w-6 shrink-0 rounded object-cover"
               />
-              <span
-                className="truncate text-xs font-semibold"
-                style={{ color: qualityColor }}
-              >
+              <span className="truncate text-xs font-semibold" style={{ color: qualityColor }}>
                 {displayName}
               </span>
             </a>
@@ -80,10 +77,7 @@ export default function MatrixView({ items, players, lookup, itemInfo }: Props) 
         {players.map((player) => {
           const result = itemResults?.get(player.member_id);
           const pct = result?.upgrade_pct;
-          const label =
-            pct !== undefined
-              ? `${pct >= 0 ? '+' : ''}${pct.toFixed(1)}`
-              : '';
+          const label = pct !== undefined ? `${pct >= 0 ? '+' : ''}${pct.toFixed(1)}` : '';
 
           return (
             <td

--- a/frontend/src/app/components/raid-roster/RosterHistory.tsx
+++ b/frontend/src/app/components/raid-roster/RosterHistory.tsx
@@ -76,7 +76,9 @@ export default function RosterHistory({ roster }: { roster: Roster }) {
         </button>
 
         <div className="text-sm text-on-surface-variant">
-          <span className="font-semibold text-on-surface">{instanceName(selected.run.instance_id)}</span>
+          <span className="font-semibold text-on-surface">
+            {instanceName(selected.run.instance_id)}
+          </span>
           {' · '}
           <span className="capitalize">{selected.run.difficulty}</span>
           {' · '}
@@ -137,7 +139,9 @@ export default function RosterHistory({ roster }: { roster: Roster }) {
                   {new Date(run.created_at).toLocaleString()}
                 </div>
               </div>
-              <div className="ml-3 shrink-0"><StatusBadge status={run.status} /></div>
+              <div className="ml-3 shrink-0">
+                <StatusBadge status={run.status} />
+              </div>
             </button>
           ))}
         </div>

--- a/frontend/src/app/components/raid-roster/RosterReportView.tsx
+++ b/frontend/src/app/components/raid-roster/RosterReportView.tsx
@@ -3,8 +3,13 @@ import { useMemo, useState } from 'react';
 import type { RosterReport, ReportPlayer } from '../../lib/rosters';
 import { useItemInfo } from '../../lib/useItemInfo';
 import {
-  EMPTY_FILTERS, type ReportFilters, type ReportViewMode,
-  filterItems, playerMap, resultLookup, sortItemsByBest,
+  EMPTY_FILTERS,
+  type ReportFilters,
+  type ReportViewMode,
+  filterItems,
+  playerMap,
+  resultLookup,
+  sortItemsByBest,
 } from './reportTypes';
 import ItemCentricView from './ItemCentricView';
 import MatrixView from './MatrixView';
@@ -15,7 +20,10 @@ export default function RosterReportView({ report }: { report: RosterReport }) {
   const [filters, setFilters] = useState<ReportFilters>(EMPTY_FILTERS);
 
   // batch-fetch item icons/quality for every item in the report (stable dep)
-  const itemQueries = useMemo(() => report.items.map((i) => ({ item_id: i.item_id })), [report.items]);
+  const itemQueries = useMemo(
+    () => report.items.map((i) => ({ item_id: i.item_id })),
+    [report.items]
+  );
   const itemInfo = useItemInfo(itemQueries);
 
   const pmap = useMemo(() => playerMap(report.players), [report.players]);
@@ -30,11 +38,16 @@ export default function RosterReportView({ report }: { report: RosterReport }) {
   // matrix column order: report players that (a) are status "ok" and (b) pass the player filter (empty = all)
   const columns: ReportPlayer[] = useMemo(() => {
     const sel = new Set(filters.players);
-    return report.players.filter((p) => p.status === 'ok' && (sel.size === 0 || sel.has(p.member_id)));
+    return report.players.filter(
+      (p) => p.status === 'ok' && (sel.size === 0 || sel.has(p.member_id))
+    );
   }, [report.players, filters]);
 
   // option lists for the filter controls
-  const playerOptions = useMemo(() => report.players.filter((p) => p.status === 'ok'), [report.players]);
+  const playerOptions = useMemo(
+    () => report.players.filter((p) => p.status === 'ok'),
+    [report.players]
+  );
   const slotOptions = useMemo(
     () => Array.from(new Set(report.items.map((i) => i.slot))).sort(),
     [report.items]
@@ -44,7 +57,10 @@ export default function RosterReportView({ report }: { report: RosterReport }) {
   function togglePlayer(memberId: string) {
     setFilters((f) => {
       const has = f.players.includes(memberId);
-      return { ...f, players: has ? f.players.filter((p) => p !== memberId) : [...f.players, memberId] };
+      return {
+        ...f,
+        players: has ? f.players.filter((p) => p !== memberId) : [...f.players, memberId],
+      };
     });
   }
 
@@ -55,10 +71,8 @@ export default function RosterReportView({ report }: { report: RosterReport }) {
     });
   }
 
-  const chipBase =
-    'rounded-full border px-2.5 py-0.5 text-xs transition-colors';
-  const chipOn =
-    'border-primary/40 bg-primary/15 text-on-surface';
+  const chipBase = 'rounded-full border px-2.5 py-0.5 text-xs transition-colors';
+  const chipOn = 'border-primary/40 bg-primary/15 text-on-surface';
   const chipOff =
     'border-outline-variant/10 bg-surface-container-high text-on-surface-variant/70 hover:text-on-surface';
 

--- a/frontend/src/app/components/raid-roster/RosterRunPanel.tsx
+++ b/frontend/src/app/components/raid-roster/RosterRunPanel.tsx
@@ -2,17 +2,8 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { API_URL, fetchJson } from '../../lib/api';
-import {
-  startRun,
-  getRun,
-  type Roster,
-  type RosterReport,
-} from '../../lib/rosters';
-import type {
-  SeasonConfigResponse,
-  DifficultyDef,
-  DifficultyGroup,
-} from '../../lib/types';
+import { startRun, getRun, type Roster, type RosterReport } from '../../lib/rosters';
+import type { SeasonConfigResponse, DifficultyDef, DifficultyGroup } from '../../lib/types';
 import type { Instance, UpgradeTracks } from '../loot/types';
 import { groupInstances } from '../../lib/instanceCategories';
 import RosterReportView from './RosterReportView';
@@ -80,7 +71,7 @@ export default function RosterRunPanel({ roster }: { roster: Roster }) {
   // Derive raids + dungeon categories (shared with DropFinderContent)
   const { raids, dungeonCats } = useMemo(
     () => groupInstances(instances, seasonConfig),
-    [instances, seasonConfig],
+    [instances, seasonConfig]
   );
 
   const isRaid = category === 'raids';
@@ -197,8 +188,7 @@ export default function RosterRunPanel({ roster }: { roster: Roster }) {
     setDone(0);
     setTotal(0);
 
-    const encounters =
-      isRaid && selectedRaidId ? Array.from(selectedBosses) : undefined;
+    const encounters = isRaid && selectedRaidId ? Array.from(selectedBosses) : undefined;
 
     const started = await startRun(roster.id, instanceId, difficulty, {
       target_error: targetError,

--- a/frontend/src/app/components/raid-roster/reportTypes.ts
+++ b/frontend/src/app/components/raid-roster/reportTypes.ts
@@ -5,7 +5,7 @@ export type ReportViewMode = 'item' | 'matrix';
 export interface ReportFilters {
   hideDowngrades: boolean;
   players: string[]; // member_ids to include; empty = all
-  slots: string[];   // slot names to include; empty = all
+  slots: string[]; // slot names to include; empty = all
 }
 
 export const EMPTY_FILTERS: ReportFilters = { hideDowngrades: false, players: [], slots: [] };

--- a/frontend/src/app/lib/instanceCategories.ts
+++ b/frontend/src/app/lib/instanceCategories.ts
@@ -13,7 +13,7 @@ import type { SeasonConfigResponse, DungeonCategory } from './types';
  */
 export function groupInstances(
   instances: Instance[],
-  seasonConfig: SeasonConfigResponse | null,
+  seasonConfig: SeasonConfigResponse | null
 ): { raids: Instance[]; dungeonCats: { cat: DungeonCategory; instances: Instance[] }[] } {
   if (!seasonConfig)
     return {

--- a/frontend/src/app/lib/rosters.ts
+++ b/frontend/src/app/lib/rosters.ts
@@ -63,7 +63,9 @@ export async function deleteMember(rosterId: string, memberId: string): Promise<
 
 export async function refreshRoster(rosterId: string): Promise<RosterMember[]> {
   try {
-    return await fetchJson<RosterMember[]>(`${API_URL}/api/rosters/${rosterId}/refresh`, { method: 'POST' });
+    return await fetchJson<RosterMember[]>(`${API_URL}/api/rosters/${rosterId}/refresh`, {
+      method: 'POST',
+    });
   } catch {
     return [];
   }
@@ -71,7 +73,10 @@ export async function refreshRoster(rosterId: string): Promise<RosterMember[]> {
 
 export async function refreshMember(rosterId: string, memberId: string): Promise<RosterMember[]> {
   try {
-    return await fetchJson<RosterMember[]>(`${API_URL}/api/rosters/${rosterId}/members/${memberId}/refresh`, { method: 'POST' });
+    return await fetchJson<RosterMember[]>(
+      `${API_URL}/api/rosters/${rosterId}/members/${memberId}/refresh`,
+      { method: 'POST' }
+    );
   } catch {
     return [];
   }

--- a/frontend/src/app/raid-roster/page.tsx
+++ b/frontend/src/app/raid-roster/page.tsx
@@ -1,12 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import {
-  getRosters,
-  createRoster,
-  deleteRoster,
-  type Roster,
-} from '../lib/rosters';
+import { getRosters, createRoster, deleteRoster, type Roster } from '../lib/rosters';
 import RosterEditor from '../components/raid-roster/RosterEditor';
 import RosterRunPanel from '../components/raid-roster/RosterRunPanel';
 import RosterHistory from '../components/raid-roster/RosterHistory';
@@ -123,7 +118,9 @@ export default function RaidRosterPage() {
                       <button
                         onClick={() => setSelectedId(r.id)}
                         className={`min-w-0 flex-1 text-left transition-colors ${
-                          isActive ? 'text-primary' : 'text-on-surface-variant hover:text-on-surface'
+                          isActive
+                            ? 'text-primary'
+                            : 'text-on-surface-variant hover:text-on-surface'
                         }`}
                       >
                         <div className="truncate text-sm font-medium">{r.name}</div>


### PR DESCRIPTION
`lint.yml` has been failing on master. `cargo fmt --all --check` flagged 13 Rust files and `prettier --check` flagged 9 frontend files, so every PR inherited those failures — including ones touching none of the affected files. #133 is currently red for exactly this reason.

That's worth fixing beyond tidiness: CI that's red by default trains everyone to stop reading it, which is how the broken `docker compose build backend` in #130 went unnoticed for two months.

Purely mechanical — `cargo fmt --all` and `prettier --write`, no hand edits.

### Verification

Run on a clean checkout of master with the changes applied:

- `cargo fmt --all -- --check` clean
- `prettier --check "src/**/*.{ts,tsx,css}"` clean
- `cargo test --all-features` — 541 passed, 0 failed
- `tsc --noEmit` clean
- `npm run lint` — 0 errors (4 pre-existing `no-img-element` warnings, unchanged)

### Note on Cargo.lock

Running the test suite regenerated `backend/Cargo.lock`, which is currently stale: `simhammer-core` and `simhammer-server` still say `4.1.0` after the v4.2.0 release. That change is deliberately **excluded** here to keep this diff formatting-only. It has its own cause — `scripts/sync-version.sh` bumps the version in `Cargo.toml` with `sed` and never refreshes the lock, so it recurs every release — and should be fixed separately.

### Merge order

Best merged before #133 so that PR's checks go green without a rebase.
