### PR TITLE
fix(toolchain): pin Rust in one place

### DIFF
--- a/.github/workflows/desktop-build-platform.yml
+++ b/.github/workflows/desktop-build-platform.yml
@@ -40,7 +40,10 @@ jobs:
             frontend/package-lock.json
             desktop/package-lock.json
 
-      - uses: dtolnay/rust-toolchain@stable
+      # No toolchain action: rustup is preinstalled on GitHub runners and
+      # resolves backend/rust-toolchain.toml, which pins the version and
+      # declares rustfmt and clippy. Pinning here too would be a second
+      # source of truth that could drift.
 
       - name: Cache Rust build
         uses: actions/cache@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,9 +39,10 @@ jobs:
         with:
           node-version: 20
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
+      # No toolchain action: rustup is preinstalled on GitHub runners and
+      # resolves backend/rust-toolchain.toml, which pins the version and
+      # declares rustfmt and clippy. Pinning here too would be a second
+      # source of truth that could drift.
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -12,7 +12,8 @@ ENV NEXT_PUBLIC_API_URL=""
 RUN npm run build
 
 # --- Stage 2: Build the Rust Backend ---
-FROM rust:1.88-alpine AS backend-builder
+# Keep this version in step with backend/rust-toolchain.toml; FROM cannot read it.
+FROM rust:1.96-alpine AS backend-builder
 RUN apk add --no-cache musl-dev
 WORKDIR /build
 # Without Cargo.lock cargo resolves every dependency from scratch, so this image

--- a/backend/rust-toolchain.toml
+++ b/backend/rust-toolchain.toml
@@ -1,0 +1,18 @@
+# Single source of truth for the Rust toolchain.
+#
+# rustup honours this file for any cargo command run inside backend/, so CI,
+# the desktop release builds and local development all compile with the same
+# compiler. Before this existed, the workflows floated on latest stable while
+# the Docker images sat on 1.88 — two different compilers producing shipped
+# artifacts (see issue #135).
+#
+# The Docker images cannot read this file (FROM takes a literal tag), so
+# backend/server/Dockerfile and Dockerfile.standalone pin the same version in
+# their FROM lines and must be bumped together with the channel below.
+#
+# components are declared here rather than installed by a CI action, so that
+# `cargo fmt` and `cargo clippy` resolve against this toolchain rather than
+# whatever happens to be default on the runner.
+[toolchain]
+channel = "1.96.0"
+components = ["rustfmt", "clippy"]

--- a/backend/server/Dockerfile
+++ b/backend/server/Dockerfile
@@ -1,4 +1,5 @@
-FROM rust:1.88-bookworm AS builder
+# Keep this version in step with backend/rust-toolchain.toml; FROM cannot read it.
+FROM rust:1.96-bookworm AS builder
 
 WORKDIR /build
 


### PR DESCRIPTION
Closes #135. Option 1 from that issue.

> Stacked on #136 — base is `fix/release-lockfiles`. Review order: #134, #133, #136, then this.

Four Rust build paths, two compilers:

| path | was |
|---|---|
| `lint.yml` | `dtolnay/rust-toolchain@stable` → 1.96 |
| `desktop-build-platform.yml` | `dtolnay/rust-toolchain@stable` → 1.96 |
| `backend/server/Dockerfile` | `rust:1.88-bookworm` |
| `Dockerfile.standalone` | `rust:1.88-alpine` |

So the desktop binaries users download and the server binary in the GHCR image were compiled by different toolchains, and the gap widens on its own: `stable` moves every six weeks, the `FROM` lines only when someone edits them.

### What changed

`backend/rust-toolchain.toml` pins `1.96.0` and declares `rustfmt` and `clippy`. rustup resolves it for any cargo command under `backend/`, so CI, desktop releases and local development now agree.

The toolchain action is **removed** from both workflows rather than pinned alongside the file — keeping it would have created a second version that could drift, which is the problem this is meant to solve. GitHub runners ship rustup, which installs the pinned toolchain and its components on first use.

`FROM` can't read the file, so both Dockerfiles pin the same version literally and carry a comment tying them to it. That's the one seam this approach can't close; bumping means editing three places, which is why they cross-reference each other.

### Verification

- `rustup show active-toolchain` under `backend/` resolves `1.96.0`, and `cargo clippy --version` reports `0.1.96` — confirming components resolve against the pin rather than the runner default.
- `docker build --target builder -f backend/server/Dockerfile backend` passes on `rust:1.96-bookworm` with `--locked`.
- `docker build -f Dockerfile.standalone .` passes on `rust:1.96-alpine` (musl) with `--locked`.
- Inspected the standalone image: server binary present (22.6 MB), `mdt_dungeons.json`, all 11 `mdt-maps/` files and the 29-entry frontend export intact.

### Not verified

The desktop workflows are `workflow_dispatch`-only, so removing the action there hasn't been exercised. Worth a manual run before relying on it for a release.

### Unrelated, but found while testing this

`cargo clippy --all-targets --all-features -- -D warnings` currently **fails on master** with 13 errors — 8 `MutexGuard` held across an await point, 2 complex types, 2 too-many-arguments, 1 empty line after doc comment. CI has never reported it because the `Check formatting` step fails first and ends the job, so #134 will expose this rather than fully green the build.

Not fixed here: 16 of the 21 locations are in `cloud_streaming.rs` and 2 in `helpers.rs`, both of which are being rewritten on an unmerged branch. Worth doing after that lands.
