### PR TITLE
fix(release): keep lockfiles in sync with the version bump

### DIFF
--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -16,15 +16,14 @@ FROM rust:1.88-alpine AS backend-builder
 RUN apk add --no-cache musl-dev
 WORKDIR /build
 # Without Cargo.lock cargo resolves every dependency from scratch, so this image
-# can ship a different dependency graph than the one CI tested. `--locked` is not
-# passed yet: the committed lockfile is currently out of sync with the manifests,
-# so it would fail the build. Add it once that is fixed.
+# can ship a different dependency graph than the one CI tested. `--locked` makes
+# that enforceable: the build fails if the lockfile drifts from the manifests.
 COPY backend/Cargo.toml backend/Cargo.lock ./
 COPY backend/core/ core/
 COPY backend/server/ server/
 COPY backend/calibration/ calibration/
 COPY backend/migrations/ migrations/
-RUN cargo build --release -p simhammer-server
+RUN cargo build --release --locked -p simhammer-server
 
 # --- Stage 3: Final Runtime ---
 # Node.js is needed to run compact-data.js at startup.

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "simhammer-core"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "actix-cors",
  "actix-files",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "simhammer-server"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "simhammer-core",
  "tokio",

--- a/backend/server/Dockerfile
+++ b/backend/server/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /build
 
 # Copy workspace files. Without Cargo.lock cargo resolves every dependency from
 # scratch, so the shipped binary's graph can drift from the one CI tested.
-# `--locked` is not passed yet: the committed lockfile is currently out of sync
-# with the manifests, so it would fail the build. Add it once that is fixed.
+# `--locked` makes that guarantee enforceable: the build fails if the lockfile
+# drifts from the manifests, which scripts/sync-version.sh now keeps in sync.
 COPY Cargo.toml Cargo.lock ./
 COPY core/ core/
 COPY server/ server/
@@ -13,7 +13,7 @@ COPY calibration/ calibration/
 COPY migrations/ migrations/
 
 ARG CARGO_FEATURES=
-RUN cargo build --release -p simhammer-server ${CARGO_FEATURES:+--features $CARGO_FEATURES}
+RUN cargo build --release --locked -p simhammer-server ${CARGO_FEATURES:+--features $CARGO_FEATURES}
 
 # --- Fetch game data from Raidbots and compact ---
 FROM node:20-slim AS fetcher

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simhammer-desktop",
-  "version": "3.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simhammer-desktop",
-      "version": "3.1.0",
+      "version": "4.2.0",
       "dependencies": {
         "electron-updater": "^6.3.9"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -60,7 +60,10 @@
       "notarize": false
     },
     "linux": {
-      "target": ["AppImage", "deb"]
+      "target": [
+        "AppImage",
+        "deb"
+      ]
     },
     "nsis": {
       "oneClick": false,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simhammer-frontend",
-  "version": "3.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simhammer-frontend",
-      "version": "3.1.0",
+      "version": "4.2.0",
       "dependencies": {
         "next": "^15.5.14",
         "react": "^18.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simhammer",
-  "version": "3.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simhammer",
-      "version": "3.1.0"
+      "version": "4.2.0"
     }
   }
 }

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -9,12 +9,18 @@ VERSION="$(tr -d '[:space:]' < "$ROOT/VERSION")"
 
 echo "Syncing version: $VERSION"
 
-# Cargo workspace
+# Cargo workspace. Cargo.lock records each workspace member's own version, so it
+# goes stale unless refreshed here, which breaks `cargo build --locked` in the
+# Docker images. `--workspace` touches only our own packages, never third-party
+# dependencies.
 sed -i "s/^version = \".*\"/version = \"$VERSION\"/" "$ROOT/backend/Cargo.toml"
+(cd "$ROOT/backend" && cargo update --workspace --offline)
 
-# package.json files
-for f in "$ROOT/frontend/package.json" "$ROOT/desktop/package.json" "$ROOT/package.json"; do
-    sed -i "s/\"version\": \".*\"/\"version\": \"$VERSION\"/" "$f"
+# npm projects. `npm version` updates package.json and package-lock.json
+# together; editing package.json alone left every lockfile stranded at 3.1.0.
+for d in "$ROOT/frontend" "$ROOT/desktop" "$ROOT"; do
+    [ -f "$d/package.json" ] || continue
+    (cd "$d" && npm version "$VERSION" --no-git-tag-version --allow-same-version >/dev/null)
 done
 
 echo "Done."


### PR DESCRIPTION
> Replaces #136, which GitHub auto-closed when its base branch `ci/docker-build-coverage` was deleted on merging #133. Same commit, rebased onto master.

`scripts/sync-version.sh` edits every manifest with `sed` and never touches a lockfile, so each release strands four of them:

| lockfile | was | should be |
|---|---|---|
| `backend/Cargo.lock` | 4.1.0 | 4.2.0 |
| `frontend/package-lock.json` | 3.1.0 | 4.2.0 |
| `desktop/package-lock.json` | 3.1.0 | 4.2.0 |
| `package-lock.json` | 3.1.0 | 4.2.0 |

The npm ones have been drifting since v3.1.0 and are harmless to `npm ci` today. The cargo one was not cosmetic: it made `cargo build --locked` fail, which is why #133 had to ship `COPY Cargo.lock` without the flag that makes it mean anything.

### What changed

`sync-version.sh` now runs `cargo update --workspace --offline` after bumping `Cargo.toml`, and uses `npm version --no-git-tag-version` instead of `sed` so `package.json` and `package-lock.json` move together.

With the lockfiles correct, `--locked` is restored in both Dockerfiles. An image can no longer be built from a dependency graph other than the one CI tested, and the `docker-build` job from #131 enforces it on every PR.

### Verification

The committed lockfiles here are the output of actually running the fixed script, not hand edits.

- `cargo update --workspace` touched only `simhammer-core` and `simhammer-server`; all 11 third-party dependencies unchanged. Every lockfile line in this diff is a version field.
- `docker build --target builder -f backend/server/Dockerfile backend` — passes with `--locked`
- `docker build -f Dockerfile.standalone .` — passes with `--locked`
- Inspected the standalone image: `mdt_dungeons.json`, all 11 `mdt-maps/` files, server binary and the 29-entry frontend export all present.

### One incidental change

`npm version` re-serialised an inline array in `desktop/package.json` (`"target": ["AppImage", "deb"]` onto three lines). Purely cosmetic. Left in rather than reverted, since the script would reproduce it on the next release anyway.
