### PR TITLE
fix(lint): make clippy -D warnings pass

### DIFF
--- a/backend/core/src/compute/cloud_streaming.rs
+++ b/backend/core/src/compute/cloud_streaming.rs
@@ -2406,7 +2406,7 @@ mod orchestrator_tests {
         run.execute(runner).await;
 
         // (a) Exactly ONE chunk submitted (single-chunk fast path).
-        let recorded = calls.lock().unwrap();
+        let recorded = calls.lock().unwrap().clone();
         assert_eq!(recorded.len(), 1, "expected exactly one chunk submission");
         assert_eq!(recorded[0].chunk_idx, 0);
         assert_eq!(recorded[0].job_id, job_id);
@@ -2416,7 +2416,6 @@ mod orchestrator_tests {
             "chunk input must carry the base-actor header: {}",
             recorded[0].simc_input
         );
-        drop(recorded);
 
         // The cloud_chunks row is recorded + completed (never re-billed).
         let cloud_repo = CloudChunksRepo::new(pool.clone());
@@ -2612,7 +2611,7 @@ mod orchestrator_tests {
         run.execute(runner).await;
 
         // Exactly 3 chunks submitted, with the expected per-chunk sizes.
-        let recorded = calls.lock().unwrap();
+        let recorded = calls.lock().unwrap().clone();
         assert_eq!(recorded.len(), 3, "expected 3 chunk submissions");
         let mut by_idx: Vec<(usize, usize)> = recorded
             .iter()
@@ -2620,7 +2619,6 @@ mod orchestrator_tests {
             .collect();
         by_idx.sort();
         assert_eq!(by_idx, vec![(0, 2), (1, 2), (2, 1)]);
-        drop(recorded);
 
         // Concurrency was bounded to K=2 (no more than 2 runners ever in flight).
         assert!(
@@ -2884,9 +2882,8 @@ mod orchestrator_tests {
         }
 
         // Submission accounting: 3 original chunk calls + 2 retry sub-chunk calls.
-        let recorded = calls.lock().unwrap();
+        let recorded = calls.lock().unwrap().clone();
         assert_eq!(recorded.len(), 5, "3 chunks + 2 retry sub-chunks");
-        drop(recorded);
 
         // The original chunk-1 row is failed; its two sub-chunk rows are completed.
         let cloud_repo = CloudChunksRepo::new(pool.clone());
@@ -3298,7 +3295,7 @@ mod orchestrator_tests {
 
         // (a) The completed chunk 0 was NOT re-submitted — the only new-chunk
         // runner call is the regenerated tail (Combo 5).
-        let recorded = calls.lock().unwrap();
+        let recorded = calls.lock().unwrap().clone();
         assert_eq!(
             recorded.len(),
             1,
@@ -3310,7 +3307,6 @@ mod orchestrator_tests {
             vec!["Combo 5".to_string()],
             "restored next_name_idx must continue naming at Combo 5 (no collision)"
         );
-        drop(recorded);
 
         // (b) The in-flight chunk 1 was re-polled exactly once.
         assert_eq!(repoll_calls.lock().unwrap().as_slice(), &["remote-1"]);
@@ -3536,7 +3532,7 @@ mod orchestrator_tests {
 
         // The tail chunk (Combo 5) was generated and submitted at a FRESH index
         // past the existing max (3), i.e. >= 4 — no PK collision.
-        let recorded = calls.lock().unwrap();
+        let recorded = calls.lock().unwrap().clone();
         assert_eq!(
             recorded.len(),
             1,
@@ -3551,7 +3547,6 @@ mod orchestrator_tests {
             "tail chunk_idx must be past the retry-tail rows (>=4), got {}",
             recorded[0].chunk_idx
         );
-        drop(recorded);
 
         // All rows completed; the tail row exists at the reconciled index.
         let rows = cloud_repo.list_for_job(&job_id).await.unwrap();
@@ -3761,7 +3756,7 @@ mod orchestrator_tests {
 
         // The pre-cursor failed chunk 1 (Combo 3,4) was re-submitted (and nothing
         // else — completed chunks are never re-submitted).
-        let recorded = calls.lock().unwrap();
+        let recorded = calls.lock().unwrap().clone();
         assert_eq!(
             recorded.len(),
             1,
@@ -3773,7 +3768,6 @@ mod orchestrator_tests {
         );
         // It re-used chunk 1's own row index (not a fresh tail index).
         assert_eq!(recorded[0].chunk_idx, 1);
-        drop(recorded);
 
         // Done with ALL 5 combos, each exactly once (chunk 1's combos recovered).
         let finished = repo.get(&job_id).await.unwrap().unwrap();
@@ -3869,13 +3863,12 @@ mod orchestrator_tests {
         // The failed-with-live-remote chunk 1 was RE-POLLED (Bug B), not regenerated.
         assert_eq!(repoll_calls.lock().unwrap().as_slice(), &["live-remote-1"]);
         // Only the tail (Combo 5) was submitted via the runner — chunk 1 was folded.
-        let recorded = calls.lock().unwrap();
+        let recorded = calls.lock().unwrap().clone();
         assert_eq!(recorded.len(), 1, "only the tail submits: {recorded:?}");
         assert_eq!(
             combo_names(&recorded[0].simc_input),
             vec!["Combo 5".to_string()]
         );
-        drop(recorded);
 
         // chunk 1 flipped failed→completed via the re-poll.
         let rows = cloud_repo.list_for_job(&job_id).await.unwrap();
@@ -3976,14 +3969,13 @@ mod orchestrator_tests {
 
         // The superseded parent (Combo 3,4) was NOT re-submitted: only the tail
         // (Combo 5) reaches the runner.
-        let recorded = calls.lock().unwrap();
+        let recorded = calls.lock().unwrap().clone();
         assert_eq!(recorded.len(), 1, "only the tail submits: {recorded:?}");
         assert_eq!(
             combo_names(&recorded[0].simc_input),
             vec!["Combo 5".to_string()]
         );
         // The parent stays `failed` (it was legitimately superseded; never resurrected).
-        drop(recorded);
         let rows = cloud_repo.list_for_job(&job_id).await.unwrap();
         assert_eq!(
             rows.iter().find(|r| r.chunk_idx == 1).unwrap().status,

--- a/backend/core/src/compute/provider.rs
+++ b/backend/core/src/compute/provider.rs
@@ -23,11 +23,14 @@ pub struct ProviderCaps {
     pub cloud_streaming: bool,
 }
 
+/// Progress callback: `(percent, stage, detail)`.
+pub type ProgressFn<'a> = Arc<dyn Fn(u8, &str, &str) + Send + Sync + 'a>;
+
 /// Callbacks passed through the `SimcProvider` trait. Arc-wrapped so providers
 /// can clone them into the multiple sub-tasks `run_simc_staged` requires.
 pub struct RunCtx<'a> {
     pub job_id: &'a str,
-    pub on_progress: Arc<dyn Fn(u8, &str, &str) + Send + Sync + 'a>,
+    pub on_progress: ProgressFn<'a>,
     pub on_stage_complete: Arc<dyn Fn(&str) + Send + Sync + 'a>,
     pub on_log: Arc<dyn Fn(&str) + Send + Sync + 'a>,
     pub cancel: Option<crate::cancel::CancelToken>,

--- a/backend/core/src/jobs/combo_metadata.rs
+++ b/backend/core/src/jobs/combo_metadata.rs
@@ -84,10 +84,10 @@ pub(crate) async fn write_combo_metadata_table_raw_offset(
     }
 }
 
-/// Convenience wrapper for handlers that have `HashMap<String, Vec<Value>>` combo_metadata
-/// (top_gear, upgrade_compare).
-// `write_combo_metadata_table`/`_value` removed: handlers now pre-serialize into
-// `ProfilesetSubmission::combo_metadata_serialized` and write via the `_raw` variant.
+// `write_combo_metadata_table`/`_value` removed — they wrapped handlers holding
+// `HashMap<String, Vec<Value>>` combo_metadata (top_gear, upgrade_compare).
+// Handlers now pre-serialize into `ProfilesetSubmission::combo_metadata_serialized`
+// and write via the `_raw` variant.
 
 /// Load combo_metadata for a job from the `combo_metadata` table.
 /// Returns an empty map for in-memory repos or when no rows exist.

--- a/backend/core/src/profileset_generator.rs
+++ b/backend/core/src/profileset_generator.rs
@@ -1946,7 +1946,9 @@ head=,id=100\n";
     // job exercising gear alternatives, a paired slot (finger1/finger2), an
     // enchant axis, a gem axis, and a talent variant. The refactor must keep
     // (simc string, count, metadata) byte-for-byte identical to this snapshot.
-    fn golden_top_gear_inputs() -> (
+    /// (base profile, gear by slot, enchants by slot, gems by slot, gem ids,
+    /// equipped item ids, talent variants)
+    type GoldenInputs = (
         String,
         HashMap<String, Vec<serde_json::Value>>,
         HashMap<String, Vec<String>>,
@@ -1954,7 +1956,9 @@ head=,id=100\n";
         Vec<u64>,
         HashSet<u64>,
         Vec<(String, String)>,
-    ) {
+    );
+
+    fn golden_top_gear_inputs() -> GoldenInputs {
         let base = "mage=test\nspec=frost\nhead=,id=100,enchant_id=7000\n\
 finger1=,id=400\nfinger2=,id=401\nmain_hand=,id=200\n"
             .to_string();

--- a/backend/core/src/server/job_spawn.rs
+++ b/backend/core/src/server/job_spawn.rs
@@ -419,6 +419,9 @@ pub(crate) async fn spawn_droptimizer_child(
     Ok(job_id)
 }
 
+// Threads the streamed run's full context into the staged phase; grouping these
+// into a struct would only move the same fields behind one more indirection.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn handoff_streamed_top_gear_to_staged(
     pool: &sqlx::AnyPool,
     repo: &JobRepo,

--- a/backend/core/src/server/top_gear_handlers.rs
+++ b/backend/core/src/server/top_gear_handlers.rs
@@ -59,6 +59,8 @@ fn build_items_by_slot(
     items_by_slot
 }
 
+// Arguments are actix extractors; the count is the framework's, not a design choice.
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn create_top_gear_sim(
     http_req: HttpRequest,
     req: web::Json<TopGearRequest>,


### PR DESCRIPTION
The `rust` job in `lint.yml` has never reached its clippy step — `cargo fmt` failed first and ended the job. With formatting fixed in #134, clippy surfaced 13 errors that had been accumulating unseen.

**Eight were false positives.** Every one is a test doing `lock()` → assert → `drop(recorded)` → `await`. The guard is already released before the await, but clippy's `await_holding_lock` does not recognise an explicit `drop()`. Rather than suppress a deadlock lint, cloning the Vec out of the guard removes the guard entirely — nothing held, nothing to lint, and the `drop()` calls become unnecessary.

**The rest:**

- The stranded `///` paragraph in `combo_metadata.rs` documented two functions that were deleted; folded into the note explaining their removal.
- `RunCtx::on_progress` and a test helper's return type get named type aliases.
- Two functions keep their argument counts behind `#[allow]`, matching the existing allow on `RosterRepo::upsert_member`. `create_top_gear_sim`'s arguments **are** actix extractors, so the count is the framework's, not a design choice; the other threads a streamed run's context into the staged phase, where a struct would only add indirection.

No behaviour change.

### Checks

- `cargo clippy --all-targets --all-features -- -D warnings` — **passes** (exit 0)
- `cargo test --all-features` — 572 passed, 0 failed
- `cargo fmt --all -- --check` — clean
- frontend: prettier clean, `tsc` clean, eslint 0 errors

This should make the `rust` job green for the first time.